### PR TITLE
update parameter vector in eval instead of copy

### DIFF
--- a/bayes/multi_model_error.py
+++ b/bayes/multi_model_error.py
@@ -93,7 +93,7 @@ class MultiModelError:
             The dimension must be identical to the number of latent variables
             (shared variables are only a single latent variable)
         """
-        updated_parameters = self.latent.update(parameter_vector)
+        updated_parameters = self.latent.update(parameter_vector, return_copy=False)
         result = OrderedDict()
         for key in self.keys:
             prm = updated_parameters[key]


### PR DESCRIPTION
Parameter vector in evaluate has to update the parameter list (instead of copying), since it returns only the error vector, but not the parameter lists. If accessing them in the likelihood (the noise terms), those have to be updated.