### PR TITLE
Fancy jacobian

### DIFF
--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -100,13 +100,13 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesInterface):
             )
         self.prm_prior[latent_name] = (mean, sd)
 
-    def set_noise_prior(self, name, gamma_or_sd_mean, sd_scale=None):
+    def set_noise_prior(self, name, gamma_or_sd_mean, sd_shape=None):
         if isinstance(gamma_or_sd_mean, Gamma):
             gamma = gamma_or_sd_mean
-            assert sd_scale is None
+            assert sd_shape is None
         else:
-            sd_scale = sd_scale or 1.0
-            gamma = Gamma.FromSD(gamma_or_sd_mean, sd_scale)
+            sd_shape = sd_shape or 1.0
+            gamma = Gamma.FromSD(gamma_or_sd_mean, sd_shape)
 
         if name not in self.noise_models:
             raise RuntimeError(

--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -3,8 +3,8 @@ from .parameters import ParameterList
 from .latent import LatentParameters
 from .noise import SingleSensorNoise
 from collections import OrderedDict
-from .vb import MVN, Gamma, variational_bayes, VariationalBayesModelError
-from .jacobian import *
+from .vb import MVN, Gamma, variational_bayes, VariationalBayesInterface
+from .jacobian import d_model_error_d_named_parameter
 
 
 class ModelErrorInterface:
@@ -86,7 +86,7 @@ class InferenceProblem:
         return log_like
 
 
-class VariationalBayesProblem(InferenceProblem, VariationalBayesModelError):
+class VariationalBayesProblem(InferenceProblem, VariationalBayesInterface):
     def __init__(self):
         super().__init__()
         self.prm_prior = {}
@@ -121,6 +121,9 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesModelError):
         return info
 
     def jacobian(self, number_vector):
+        """
+        overwrites VariationalBayesInterface.jacobian
+        """
         self.latent.update(number_vector)
         jac = {}
         for key, me in self.model_errors.items():
@@ -182,6 +185,9 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesModelError):
         return jacs_by_noise
 
     def __call__(self, number_vector):
+        """
+        overwrites VariationalBayesInterface.__call__
+        """
         me = super().__call__(number_vector)
 
         errors_by_noise = {}

--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -39,7 +39,7 @@ class ModelErrorInterface:
         prm0 = self.parameter_list[prm_name]
         dx = prm0 * 1.0e-7  # approx prm * sqrt(machine precision)
         if dx == 0:
-            dx = 1.0e-10
+            dx = 1.0e-7
 
         self.parameter_list[prm_name] = prm0 - dx
         me0 = self()
@@ -59,7 +59,7 @@ class ModelErrorInterface:
         for row in range(N):
             dx = prm0[row] * 1.0e-7  # approx prm * sqrt(machine precision)
             if dx == 0:
-                dx = 1.0e-10
+                dx = 1.0e-7
 
             self.parameter_list[prm_name][row] = prm0[row] - dx
             me0 = self()

--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -3,7 +3,7 @@ from .parameters import ParameterList
 from .latent import LatentParameters
 from .noise import SingleNoise
 from collections import OrderedDict
-from .vb import vb_new, MVN, Gamma
+from .vb import MVN, Gamma
 
 
 class ModelErrorInterface:

--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -22,13 +22,7 @@ class ModelErrorInterface:
         jac = dict()
         latent_names = latent_names or self.parameter_list.names
         for prm_name in latent_names:
-
-            try:
-                N = len(self.parameter_list[prm_name])
-                prm_jac = d_model_error_d_vector_parameter(self, prm_name)
-            except TypeError:
-                prm_jac = d_model_error_d_scalar_parameter(self, prm_name)
-
+            prm_jac = d_model_error_d_named_parameter(self, prm_name)
             for key in prm_jac:
                 if key not in jac:
                     jac[key] = dict()

--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -117,8 +117,7 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesModelError):
 
     def run(self):
         MVN = self.prior_MVN()
-        noise = self.prior_noise()
-        info = variational_bayes(self, MVN, noise)
+        info = variational_bayes(self, MVN, self.noise_prior)
         return info
 
     def jacobian(self, number_vector):
@@ -207,6 +206,3 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesModelError):
                 precs.append(1.0 / sd ** 2)
 
         return MVN(means, np.diag(precs))
-
-    def prior_noise(self):
-        return self.noise_prior

--- a/bayes/jacobian.py
+++ b/bayes/jacobian.py
@@ -24,7 +24,7 @@ def d_model_error_d_vector(model_error, number_vector):
         fs0 = model_error(x)
         x[iParam] += 2 * dx
         fs1 = model_error(x)
-        x[iParam] -= dx
+        x[iParam] = number_vector[iParam]
 
         if iParam == 0:
             # allocate jac

--- a/bayes/jacobian.py
+++ b/bayes/jacobian.py
@@ -1,0 +1,105 @@
+import numpy as np
+
+
+def d_model_error_d_vector(model_error, number_vector):
+    """
+    Calculates the derivative of `model_error` w.r.t `number_vector`
+
+    model_error:
+        function that takes the single argument of type `number_vector` and
+        returns a dict of type {key : numpy_vector of length N}
+    number_vector:
+        vector of numbers of length M
+    returns:
+        dict of type {key : numpy_matrix of shape NxM}
+    """
+    x = np.copy(number_vector)
+
+    for iParam in range(len(x)):
+        dx = x[iParam] * 1.0e-7  # approx x0 * sqrt(machine precision)
+        if dx == 0:
+            dx = 1.0e-10
+
+        x[iParam] -= dx
+        fs0 = model_error(x)
+        x[iParam] += 2 * dx
+        fs1 = model_error(x)
+        x[iParam] -= dx
+
+        if iParam == 0:
+            # allocate jac
+            jac = {}
+            for noise_key, f0 in fs0.items():
+                jac[noise_key] = np.empty([len(f0), len(x)])
+
+        for n in fs0:
+            jac[n][:, iParam] = -(fs1[n] - fs0[n]) / (2 * dx)
+
+    return jac
+
+
+def d_model_error_d_scalar_parameter(model_error, prm_name):
+    """
+    Calculates the derivative of `model_error` w.r.t the named parameter 
+    `prm_name`.
+
+    model_error:
+        object that has an attribute `parameter_list` and a __call__() method
+        that returns a dict of type {key : numpy_vector of length N}
+    prm_name:
+        name of a named scalar parameter in `model_error.parameter_list` 
+    returns:
+        dict of type {key : numpy_vector of length N}
+    """
+    prm0 = model_error.parameter_list[prm_name]
+    dx = prm0 * 1.0e-7  # approx prm * sqrt(machine precision)
+    if dx == 0:
+        dx = 1.0e-7
+
+    model_error.parameter_list[prm_name] = prm0 - dx
+    me0 = model_error()
+    model_error.parameter_list[prm_name] = prm0 + dx
+    me1 = model_error()
+    model_error.parameter_list[prm_name] = prm0
+
+    jac = dict()
+    for key in me0:
+        jac[key] = (me1[key] - me0[key]) / (2 * dx)
+    return jac
+
+
+def d_model_error_d_vector_parameter(model_error, prm_name):
+    """
+    Calculates the derivative of `model_error` w.r.t the named parameter 
+    `prm_name`.
+
+    model_error:
+        object that has an attribute `parameter_list` and a __call__() method
+        that returns a dict of type {key : numpy_vector of length N}
+    prm_name:
+        name of a named vector parameter in `model_error.parameter_list` of 
+        length M
+    returns:
+        dict of type {key : numpy_matrix of length NxM}
+    """
+    prm0 = np.copy(model_error.parameter_list[prm_name])
+    M = len(prm0)
+    jac = dict()
+
+    for row in range(M):
+        dx = prm0[row] * 1.0e-7  # approx prm * sqrt(machine precision)
+        if dx == 0:
+            dx = 1.0e-7
+
+        model_error.parameter_list[prm_name][row] = prm0[row] - dx
+        me0 = model_error()
+        model_error.parameter_list[prm_name][row] = prm0[row] + dx
+        me1 = model_error()
+        model_error.parameter_list[prm_name][row] = prm0[row]
+
+        for key in me0:
+            if key not in jac:
+                jac[key] = np.empty((len(me0[key]), M))
+
+            jac[key][:, row] = (me1[key] - me0[key]) / (2 * dx)
+    return jac

--- a/bayes/jacobian.py
+++ b/bayes/jacobian.py
@@ -38,6 +38,13 @@ def d_model_error_d_vector(model_error, number_vector):
     return jac
 
 
+def d_model_error_d_named_parameter(model_error, prm_name):
+    if hasattr(model_error.parameter_list[prm_name], "__len__"):
+        return d_model_error_d_vector_parameter(model_error, prm_name)
+    else:
+        return d_model_error_d_scalar_parameter(model_error, prm_name)
+
+
 def d_model_error_d_scalar_parameter(model_error, prm_name):
     """
     Calculates the derivative of `model_error` w.r.t the named parameter 

--- a/bayes/latent.py
+++ b/bayes/latent.py
@@ -151,3 +151,14 @@ class LatentParameters(OrderedDict):
         for latent_name, latent in self.items():
             s += f"{latent_name:{l_max}} = {latent.value()}\n"
         return s
+
+    def latent_names(self, parameter_list):
+        """
+        Returns the latent parameter names of `parameter_list`.
+        """
+        names = []
+        for global_name, latent in self.items():
+            for (prm_list, local_name) in latent:
+                if prm_list == parameter_list:
+                    names.append((local_name, global_name))
+        return names

--- a/bayes/noise.py
+++ b/bayes/noise.py
@@ -35,7 +35,20 @@ class SingleSensorNoise(NoiseModelInterface):
                 )
             for sensor_me in exp_me.values():
                 vector_terms.append(sensor_me)
-        return np.concatenate(vector_terms)
+        return vector_terms
+
+    def jacobian_contribution(self, raw_jacobian):
+        jacobian_terms = []
+        for exp_jacobian in raw_jacobian.values():
+            if not isinstance(exp_jacobian, dict):
+                raise RuntimeError(
+                    "The `SingleSensorNoise` model assumes that your model "
+                    "error returns a dict {some_key : numbers}, but yours did "
+                    "not. Use `SingleNoise` instead."
+                )
+            for sensor_jacobian in exp_jacobian.values():
+                jacobian_terms.append(sensor_jacobian)
+        return jacobian_terms
 
 
 class SingleNoise(NoiseModelInterface):

--- a/bayes/noise.py
+++ b/bayes/noise.py
@@ -35,7 +35,7 @@ class SingleSensorNoise(NoiseModelInterface):
                 )
             for sensor_me in exp_me.values():
                 vector_terms.append(sensor_me)
-        return vector_terms
+        return np.concatenate(vector_terms)
 
     def jacobian_contribution(self, raw_jacobian):
         jacobian_terms = []
@@ -48,27 +48,9 @@ class SingleSensorNoise(NoiseModelInterface):
                 )
             for sensor_jacobian in exp_jacobian.values():
                 jacobian_terms.append(sensor_jacobian)
-        return jacobian_terms
 
-
-class SingleNoise(NoiseModelInterface):
-    """
-    Noise model with single term for _all_ contributions of the model error.
-    The difference to `SingleSensorNoise` is that each model error is assumed
-    to be just a vector instead of a dict with sensor key.
-    """
-
-    def vector_contribution(self, raw_me):
-        vector_terms = []
-        for exp_me in raw_me.values():
-            if isinstance(exp_me, dict):
-                raise RuntimeError(
-                    "The `SingleNoise` model assumes that your model error "
-                    "returns just a list of numbers (e.g. numpy array), "
-                    "yours returned a dict. Use `SingleSensorNoise` instead."
-                )
-            vector_terms.append(exp_me)
-        return np.concatenate(vector_terms)
+        jacobian = np.vstack(jacobian_terms)
+        return jacobian
 
 
 class UncorrelatedNoiseTerm(NoiseModelInterface):

--- a/bayes/noise.py
+++ b/bayes/noise.py
@@ -78,6 +78,12 @@ class UncorrelatedNoiseTerm(NoiseModelInterface):
         sigma = 1.0 / self.parameter_list["precision"] ** 0.5
         return self._loglike_term(error, sigma)
 
+    def jacobian_contribution(self, raw_jacobian):
+        jacobian_terms = []
+        for (sensor, key) in self.terms:
+            jacobian_terms.append(raw_jacobian[key][sensor])
+        jacobian = np.vstack(jacobian_terms)
+        return jacobian
 
 class UncorrelatedSensorNoise(NoiseModelInterface):
     """

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -41,17 +41,17 @@ class MVN:
 
 
 class Gamma:
-    def __init__(self, s=1.0, c=1.0, name="Gamma"):
-        self.s = s  # shape
-        self.c = c  # scale
+    def __init__(self, shape=1.0, scale=1.0, name="Gamma"):
+        self.scale = scale
+        self.shape = shape
         self.name = name
 
     @property
     def mean(self):
-        return self.s * self.c
+        return self.scale * self.shape
 
     def pdf(self, xs):
-        return scipy.stats.gamma.pdf(xs, a=self.s, scale=self.c)
+        return scipy.stats.gamma.pdf(xs, a=self.shape, scale=self.scale)
 
     def __repr__(self):
         return f"{self.name} with \n └── mean: {self.mean, 9}"
@@ -68,7 +68,7 @@ class Gamma:
         or
         https://math.stackexchange.com/questions/449234/vague-gamma-prior
         """
-        return cls(s=1.0 / 3.0, c=0.0)
+        return cls(scale=1.0 / 3.0, shape=0.0)
 
 
 def plot_pdf(
@@ -246,7 +246,7 @@ class VBResult:
             self.param = MVN(mean, precision)
 
             for n in shapes:
-                self.noise[n] = Gamma(s=shapes[n], c=scales[n])
+                self.noise[n] = Gamma(shape=shapes[n], scale=scales[n])
 
 
 class VB:
@@ -312,8 +312,8 @@ class VB:
         # adapt notation
         s, c = {}, {}
         for n, gamma in noise0.items():
-            s[n] = gamma.s
-            c[n] = gamma.c
+            s[n] = gamma.scale
+            c[n] = gamma.shape
         m = np.copy(param0.mean)
         L = np.copy(param0.precision)
 
@@ -386,7 +386,7 @@ class VB:
                         )
             logger.debug(f"Free energy of iteration {i_iter} is {f_new}")
 
-            self.result.try_update(f_new, m, L, s, c)
+            self.result.try_update(f_new, m, L, c, s)
             if self.stop_criteria(f_new, i_iter):
                 break
 

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -2,6 +2,7 @@ import copy
 import numpy as np
 import scipy.stats
 import scipy.special as special
+from .jacobian import d_model_error_d_vector
 
 import logging
 
@@ -130,30 +131,7 @@ class VariationalBayesModelError:
         By default, this is a numeric Jacobian calculated by central
         differences.
         """
-        x = np.copy(number_vector)
-
-        for iParam in range(len(x)):
-            dx = x[iParam] * 1.0e-7  # approx x0 * sqrt(machine precision)
-            if dx == 0:
-                dx = 1.0e-10
-
-            x[iParam] -= dx
-            fs0 = self(x)
-            x[iParam] += 2 * dx
-            fs1 = self(x)
-            x[iParam] -= dx
-
-            if iParam == 0:
-                # allocate jac
-                jac = {}
-                for noise_key, f0 in fs0.items():
-                    jac[noise_key] = np.empty([len(f0), len(x)])
-
-            for n in fs0:
-                jac[n][:, iParam] = -(fs1[n] - fs0[n]) / (2 * dx)
-
-        return jac
-
+        return d_model_error_d_vector(self, number_vector)
 
 class VBModelErrorWrapper(VariationalBayesModelError):
     def __init__(self, any_me):

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -305,10 +305,14 @@ class VB:
 
         k, J = model_error(param0.mean), model_error.jacobian(param0.mean)
 
+        return_single_noise = False
+
         if noise0 is None:
             noise0 = {noise_key: Gamma.Noninformative() for noise_key in k}
+            if len(noise0) == 1:
+                return_single_noise = True
 
-        return_single_noise = False
+
         if isinstance(noise0, Gamma):
             # if a single Gamma is provided as prior, a single noise should
             # be returned as posterior.
@@ -427,9 +431,10 @@ class VB:
 
         if f_new > self.f_old:
             self.n_trials = 0
-            # Update free energy here such that the "stop_criteria" is testable
-            # individually:
-            self.result.f_max = f_new
+
+        # Update free energy here such that the "stop_criteria" is testable
+        # individually:
+        self.result.f_max = max(self.result.f_max, f_new)
 
         # stop?
         if self.n_trials >= self.n_trials_max:

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -495,9 +495,9 @@ class VBNew:
 
         # adapt notation
         s, c = {}, {}
-        for noise_key, gamma in noise0.items():
-            s[noise_key] = gamma.s
-            c[noise_key] = gamma.c
+        for n, gamma in noise0.items():
+            s[n] = gamma.s
+            c[n] = gamma.c
         m = np.copy(param0.mean)
         L = np.copy(param0.precision)
 
@@ -515,11 +515,11 @@ class VBNew:
             L = np.copy(L0)
             Lm = L0 @ m0
 
-            for noise_key in noise0:
-                k, J = ks[noise_key], Js[noise_key]
+            for n in noise0:
+                k, J = ks[n], Js[n]
                 for i in range(len(k)):
-                    L += s[noise_key] * c[noise_key] * J[i].T @ J[i]
-                    Lm += s[noise_key] * c[noise_key] * J[i].T @ (k[i] + J[i] @ m)
+                    L += s[n] * c[n] * J[i].T @ J[i]
+                    Lm += s[n] * c[n] * J[i].T @ (k[i] + J[i] @ m)
             
             L_inv = np.linalg.inv(L)
             m = Lm @ L_inv
@@ -527,17 +527,17 @@ class VBNew:
             ks, Js = model_error(m), model_error.jacobian(m)
 
             # noise parameter update
-            for noise_key in noise0:
-                k, J = ks[noise_key], Js[noise_key]
+            for n in noise0:
+                k, J = ks[n], Js[n]
                 # formula (30)
                 N = sum([len(k_entry) for k_entry in k])
-                c[noise_key] = N / 2 + c0[noise_key]
+                c[n] = N / 2 + c0[n]
                 # formula (31)
-                s_inv = 1/s0[noise_key]
+                s_inv = 1/s0[n]
                 for i in range(len(k)):
                     s_inv += 0.5 * k[i].T @ k[i] + 0.5 * np.trace(L_inv @ J[i].T @ J[i])
                 
-                s[noise_key] = 1 / s_inv
+                s[n] = 1 / s_inv
 
             if "index_ARD" in kwargs:
                 index_ARD = kwargs["index_ARD"]

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -512,7 +512,7 @@ class VBNew:
         while True:
             i_iter += 1
 
-            L = L0
+            L = np.copy(L0)
             Lm = L0 @ m0
 
             for noise_key in noise0:
@@ -602,10 +602,6 @@ class VBNew:
 
     def stop_criteria(self, prms, f_new, i_iter):
         self.n_trials += 1
-        if i_iter> 20:
-            return True
-        else:
-            return False
 
         # parameter update
         self.result.free_energies.append(f_new)

--- a/tests/sampling_example.py
+++ b/tests/sampling_example.py
@@ -131,8 +131,8 @@ if __name__ == "__main__":
     noise_key1 = problem.add_noise_model(noise1)
     noise_key2 = problem.add_noise_model(noise2)
 
-    problem.set_noise_prior(noise_key1, 3 * noise_sd1)
-    problem.set_noise_prior(noise_key2, 3 * noise_sd2)
+    problem.set_noise_prior(noise_key1, 3 * noise_sd1, sd_shape=0.5)
+    problem.set_noise_prior(noise_key2, 3 * noise_sd2, sd_shape=0.5)
 
     info = problem.run()
     print(info)
@@ -184,8 +184,8 @@ if __name__ == "__main__":
 
         for name, gamma in problem.noise_prior.items():
             idx = problem.latent[name].start_idx
-            s, c = gamma.scale, gamma.shape
-            alpha, beta = s, 1.0 / c
+            shape, scale = gamma.shape, gamma.scale
+            alpha, beta = shape, 1.0 / scale
             pymc3_prior[idx] = pm.Gamma(name, alpha=alpha, beta=beta)
 
     """

--- a/tests/sampling_example.py
+++ b/tests/sampling_example.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 
 from bayes.parameters import ParameterList
-from bayes.inference_problem import VariationalBayesProblem, ModelError
+from bayes.inference_problem import VariationalBayesProblem, ModelErrorInterface
 from bayes.noise import UncorrelatedNoiseTerm
 
 """
@@ -50,7 +50,7 @@ class MyForwardModel:
         return p
 
 
-class MyModelError(ModelError):
+class MyModelError(ModelErrorInterface):
     def __init__(self, fw, data):
         self._fw = fw
         self._ts, self._sensor_data = data
@@ -206,7 +206,7 @@ if __name__ == "__main__":
     summary = pm.summary(trace)
     print(summary)
 
-    print(1.0 / info.noise[0].mean ** 0.5, 1.0 / info.noise[1].mean ** 0.5)
+    print(1.0 / info.noise[noise_key1].mean ** 0.5, 1.0 / info.noise[noise_key2].mean ** 0.5)
 
     means = summary["mean"]
     print(1.0 / means[noise_key1] ** 0.5, 1.0 / means[noise_key2] ** 0.5)

--- a/tests/sampling_example.py
+++ b/tests/sampling_example.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
 
         for name, gamma in problem.noise_prior.items():
             idx = problem.latent[name].start_idx
-            s, c = gamma.s, gamma.c
+            s, c = gamma.scale, gamma.shape
             alpha, beta = s, 1.0 / c
             pymc3_prior[idx] = pm.Gamma(name, alpha=alpha, beta=beta)
 

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -67,7 +67,7 @@ class TestCorrelatedVB(unittest.TestCase):
             return (fw(prm) - data) @ transformation
 
         param_prior = bayes.vb.MVN([6, 11], [[1 / 3 ** 2, 0], [0, 1 / 3 ** 2]])
-        noise_prior = bayes.vb.Gamma(s=0.1, c=1000)
+        noise_prior = bayes.vb.Gamma(shape=0.1, scale=1000)
 
         result = bayes.vb.variational_bayes(model_error, param_prior, noise_prior)
         self.assertTrue(result.success)

--- a/tests/test_inference_problem.py
+++ b/tests/test_inference_problem.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 from bayes.vb import Gamma
 from bayes.parameters import ParameterList
-from bayes.noise import SingleNoise
+from bayes.noise import SingleSensorNoise
 from bayes.inference_problem import VariationalBayesProblem, InferenceProblem
 
 
@@ -13,7 +13,7 @@ class ModelError:
 
     def __call__(self):
         x = np.linspace(0, 1, 10)
-        return x * self.parameter_list["B"]
+        return {"dummy": x * self.parameter_list["B"]}
 
 
 class TestProblem(unittest.TestCase):
@@ -46,13 +46,13 @@ class TestVBProblem(unittest.TestCase):
         self.assertRaises(Exception, p.set_normal_prior, "not B", 0.0, 1.0)
 
         self.assertRaises(Exception, p.set_noise_prior, "noise", 1.0, 1.0)
-        p.add_noise_model(SingleNoise(), key="noise")
+        p.add_noise_model(SingleSensorNoise(), key="noise")
         p.set_noise_prior("noise", 1.0, 1.0)
         p.set_noise_prior("noise", Gamma.Noninformative())
 
         result = p([0.1])
         self.assertEqual(len(result), 1)  # one noise group
-        self.assertEqual(len(result[0]), 10)
+        self.assertEqual(len(result["noise"]), 10)
 
 
 if __name__ == "__main__":

--- a/tests/test_inference_problem.py
+++ b/tests/test_inference_problem.py
@@ -13,7 +13,7 @@ class ModelError:
 
     def __call__(self):
         x = np.linspace(0, 1, 10)
-        return {"dummy": x * self.parameter_list["B"]}
+        return {"dummy_sensor": x * self.parameter_list["B"]}
 
 
 class TestProblem(unittest.TestCase):

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -3,7 +3,7 @@ import numpy as np
 from bayes.inference_problem import ModelErrorInterface
 
 
-class TestModelError(ModelErrorInterface):
+class DummyME(ModelErrorInterface):
     def __init__(self):
         super().__init__()
         self.parameter_list.define("A", 42.0)
@@ -15,7 +15,7 @@ class TestModelError(ModelErrorInterface):
         return {"out1": self.xs * A + B ** 2, "out2": self.xs * A ** 2 + B * self.xs}
 
 
-class TestModelErrorVectorPrm(ModelErrorInterface):
+class DummyMEVectorPrm(ModelErrorInterface):
     def __init__(self):
         super().__init__()
         self.parameter_list.define("X", [1.0, 2.0, 3.0])
@@ -25,7 +25,7 @@ class TestModelErrorVectorPrm(ModelErrorInterface):
         return {"out": np.concatenate([x ** 2, x ** 3])}
 
 
-class TestModelErrorVectorPrm2(ModelErrorInterface):
+class DummyMEVectorPrm2(ModelErrorInterface):
     def __init__(self):
         super().__init__()
         self.parameter_list.define("X", [0.0, 42.0])
@@ -36,7 +36,7 @@ class TestModelErrorVectorPrm2(ModelErrorInterface):
 
 class TestJacobian(unittest.TestCase):
     def test_scalar_prm(self):
-        me = TestModelError()
+        me = DummyME()
         A, B = me.parameter_list["A"], me.parameter_list["B"]
         jac = me.jacobian()
         check = np.testing.assert_array_almost_equal  # just to make it shorter
@@ -46,7 +46,7 @@ class TestJacobian(unittest.TestCase):
         check(jac["out2"]["B"], me.xs)
 
     def test_vector_prm(self):
-        me = TestModelErrorVectorPrm()
+        me = DummyMEVectorPrm()
         x = np.asarray(me.parameter_list["X"])
         jac = me.jacobian()
 
@@ -54,7 +54,7 @@ class TestJacobian(unittest.TestCase):
         np.testing.assert_array_almost_equal(jac["out"]["X"], jac_correct)
 
     def test_vector_prm2(self):
-        me = TestModelErrorVectorPrm2()
+        me = DummyMEVectorPrm2()
         jac = me.jacobian()
 
         jac_correct = np.array([[1, 1]])

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -92,6 +92,5 @@ class TestJacobian(unittest.TestCase):
         check(jac["out2"]["A"], me.xs * 2 * A)
         check(jac["out2"]["B"], me.xs)
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -1,0 +1,39 @@
+import unittest
+import numpy as np
+from bayes.inference_problem import ModelErrorInterface
+
+
+class TestModelError(ModelErrorInterface):
+    def __init__(self):
+        super().__init__()
+        self.parameter_list.define("A", 17.0)
+        self.parameter_list.define("B", 42.0)
+        self.xs = np.linspace(0.0, 1.0, 3)
+
+    def __call__(self):
+        A, B = self.parameter_list["A"], self.parameter_list["B"]
+        return {"out1": self.xs * A + B ** 2, "out2": self.xs * A ** 2 + B * self.xs}
+
+
+class TestModelErrorPartial(TestModelError):
+    def jacobian():
+        jac = super().jacobian()
+        return jac
+
+
+class TestJacobian(unittest.TestCase):
+    def check_jac(self, me):
+        A, B = me.parameter_list["A"], me.parameter_list["B"]
+        jac = me.jacobian()
+        check = np.testing.assert_array_almost_equal  # just to make it shorter
+        check(jac["out1"]["A"], me.xs)
+        check(jac["out1"]["B"], 2 * B * np.ones_like(me.xs))
+        check(jac["out2"]["A"], me.xs * 2 * A)
+        check(jac["out2"]["B"], me.xs)
+
+    def test_scalar_prm(self):
+        self.check_jac(TestModelError())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -6,8 +6,8 @@ from bayes.inference_problem import ModelErrorInterface
 class TestModelError(ModelErrorInterface):
     def __init__(self):
         super().__init__()
-        self.parameter_list.define("A", 17.0)
-        self.parameter_list.define("B", 42.0)
+        self.parameter_list.define("A", 42.0)
+        self.parameter_list.define("B", 0.0)
         self.xs = np.linspace(0.0, 1.0, 3)
 
     def __call__(self):
@@ -23,6 +23,15 @@ class TestModelErrorVectorPrm(ModelErrorInterface):
     def __call__(self):
         x = np.asarray(self.parameter_list["X"])
         return {"out": np.concatenate([x ** 2, x ** 3])}
+
+
+class TestModelErrorVectorPrm2(ModelErrorInterface):
+    def __init__(self):
+        super().__init__()
+        self.parameter_list.define("X", [0.0, 42.0])
+
+    def __call__(self):
+        return {"out": np.r_[6174 + sum(self.parameter_list["X"])]}
 
 
 class TestJacobian(unittest.TestCase):
@@ -42,6 +51,13 @@ class TestJacobian(unittest.TestCase):
         jac = me.jacobian()
 
         jac_correct = np.concatenate([np.diag(2 * x), np.diag(3 * x ** 2)])
+        np.testing.assert_array_almost_equal(jac["out"]["X"], jac_correct)
+
+    def test_vector_prm2(self):
+        me = TestModelErrorVectorPrm2()
+        jac = me.jacobian()
+
+        jac_correct = np.array([[1, 1]])
         np.testing.assert_array_almost_equal(jac["out"]["X"], jac_correct)
 
 

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -15,6 +15,28 @@ class DummyME(ModelErrorInterface):
         return {"out1": self.xs * A + B ** 2, "out2": self.xs * A ** 2 + B * self.xs}
 
 
+class DummyMEPartial(ModelErrorInterface):
+    def __init__(self):
+        super().__init__()
+        self.parameter_list.define("A", 42.0)
+        self.parameter_list.define("B", 0.0)
+        self.xs = np.linspace(0.0, 1.0, 3)
+
+    def __call__(self):
+        A, B = self.parameter_list["A"], self.parameter_list["B"]
+        return {"out1": self.xs * A + B ** 2, "out2": self.xs * A ** 2 + B * self.xs}
+
+    def jacobian(self):
+        """
+        We can provide the derivative w.r.t. "A" analytically and use the
+        central differences of the superclass for the parameter "B".
+        """
+        jac = super().jacobian(["B"])
+        jac["out1"]["A"] = self.xs
+        jac["out2"]["A"] = 2 * self.parameter_list["A"] * self.xs
+        return jac
+
+
 class DummyMEVectorPrm(ModelErrorInterface):
     def __init__(self):
         super().__init__()
@@ -59,6 +81,16 @@ class TestJacobian(unittest.TestCase):
 
         jac_correct = np.array([[1, 1]])
         np.testing.assert_array_almost_equal(jac["out"]["X"], jac_correct)
+
+    def test_partial_jacobian_definition(self):
+        me = DummyMEPartial()
+        A, B = me.parameter_list["A"], me.parameter_list["B"]
+        jac = me.jacobian()
+        check = np.testing.assert_array_almost_equal  # just to make it shorter
+        check(jac["out1"]["A"], me.xs)
+        check(jac["out1"]["B"], 2 * B * np.ones_like(me.xs))
+        check(jac["out2"]["A"], me.xs * 2 * A)
+        check(jac["out2"]["B"], me.xs)
 
 
 if __name__ == "__main__":

--- a/tests/test_multiple_models.py
+++ b/tests/test_multiple_models.py
@@ -7,8 +7,8 @@ from bayes.noise import SingleSensorNoise
 
 np.random.seed(6174)
 
-A1, B1, A2, B2 = 1.0, 2.0, 3.0, 4.0
-noise_sd = 0.1
+A1, B1, A2, B2 = 100.0, 200.0, 300.0, 400.0
+noise_sd = 12.
 
 N = 2000
 xs = np.linspace(0, 1, N)
@@ -65,7 +65,7 @@ class Test_VB(unittest.TestCase):
             posterior_mean = param_post.mean[i]
             posterior_std = param_post.std_diag[i]
 
-            self.assertLess(posterior_std, 0.4)
+            self.assertLess(posterior_std, 4)
             self.assertAlmostEqual(posterior_mean, param_true, delta=2 * posterior_std)
 
         if noise_key is None:
@@ -74,7 +74,7 @@ class Test_VB(unittest.TestCase):
             post_noise_precision = noise_post[noise_key].mean
 
         post_noise_std = 1.0 / post_noise_precision ** 0.5
-        self.assertAlmostEqual(post_noise_std, noise_sd, delta=noise_sd / 5)
+        self.assertAlmostEqual(post_noise_std, noise_sd, delta=noise_sd / 100)
 
         self.assertLess(info.nit, 20)
 
@@ -130,7 +130,7 @@ class Test_VB(unittest.TestCase):
         problem.set_normal_prior("B1", B1 + 0.5, 2)
         problem.set_normal_prior("A2", A2 + 0.5, 2)
         problem.set_normal_prior("B2", B2 + 0.5, 2)
-        
+
         noise_key = problem.add_noise_model(SingleSensorNoise())
         problem.set_noise_prior(noise_key, Gamma.Noninformative())
 

--- a/tests/test_vb.py
+++ b/tests/test_vb.py
@@ -86,7 +86,7 @@ class Test_VB(unittest.TestCase):
                 posterior_mean, param_true[i], delta=2 * posterior_std
             )
 
-        post_noise_precision = noise_post[0].mean
+            post_noise_precision = noise_post["noise0"].mean
         post_noise_sd = 1.0 / post_noise_precision ** 0.5
         self.assertAlmostEqual(post_noise_sd, noise_sd, delta=noise_sd / 100)
 

--- a/tests/test_vb.py
+++ b/tests/test_vb.py
@@ -2,9 +2,10 @@ import numpy as np
 import unittest
 from bayes.vb import *
 
+
 class ForwardModel:
     def __init__(self):
-        self.xs = np.linspace(.01, .1, 10)
+        self.xs = np.linspace(0.01, 0.1, 10)
 
     def __call__(self, parameters):
         m, c = parameters
@@ -18,25 +19,6 @@ class ForwardModel:
         return np.array([d_dm, d_dc]).T
 
 
-def stack_data(model_response, n_data, noise_std = None):
-    """
-    Creates a big vector by stacking `model_response` `n_data` times.
-
-    If noise_std is not none, it adds a normal distribution with
-    mean=0 and std=noise_std. This can be used to create noisy data.
-
-    The idea: Use the same method for both stacking the model response _and_
-    creating the data, such that the ordering cannot be messed up.
-    """
-    result = np.repeat(model_response, n_data, axis=0)
-
-    if noise_std is not None:
-        result += np.random.normal(0, noise_std, len(result))
-
-    return result
-
-
-
 class ModelError:
     def __init__(self, forward_model, data):
         """
@@ -48,32 +30,33 @@ class ModelError:
         self._forward_model = forward_model
         self._data = data
 
-        if not hasattr(forward_model, "jacobian"):
-            delattr(self, "jacobian")
-
     def __call__(self, parameters):
         model = self._forward_model(parameters)
-        repetitions = self._data.shape[0] // model.shape[0]
+        errors = []
+        for data in self._data:
+            errors.append(model - data)
 
-        return self._data - stack_data(model, repetitions)
+        return {"noise0": errors}
 
-class ModelErrorWithJacobian(ModelError): 
+
+class ModelErrorWithJacobian(ModelError):
     def jacobian(self, parameters):
-        jac = self._forward_model.jacobian(parameters)
-        repetitions = self._data.shape[0] // jac.shape[0]
-        return stack_data(jac, repetitions)
+        jac = -self._forward_model.jacobian(parameters)
+        return {"noise0": [jac] * len(self._data)}
 
 
 class Test_VB(unittest.TestCase):
-
     def run_vb(self, n_data, given_jac=False, plot=False):
         np.random.seed(6174)
 
         fw = ForwardModel()
-        param_true = (7., 10.)
-        noise_std = 0.1
+        param_true = (7.0, 10.0)
+        noise_sd = 0.1
 
-        data = stack_data(fw(param_true), n_data, noise_std)
+        data = []
+        perfect_data = fw(param_true)
+        for _ in range(n_data):
+            data.append(perfect_data + np.random.normal(0, noise_sd, len(perfect_data)))
 
         if given_jac:
             me = ModelErrorWithJacobian(fw, data)
@@ -81,35 +64,44 @@ class Test_VB(unittest.TestCase):
             me = ModelError(fw, data)
 
         param_prior = MVN([6, 11], [[1 / 3 ** 2, 0], [0, 1 / 3 ** 2]])
-        noise_prior = Gamma(s=0.1, c=1000)
+        noise_prior = {"noise0": Gamma(s=0.1, c=1000)}
 
-        info = variational_bayes(me, param_prior, noise_prior)
+        info = vb_new(me, param_prior, noise_prior)
         param_post, noise_post = info.param, info.noise
 
         if plot:
-            plot_pdf(param_post, expected_value=param_true, compare_with=param_prior, plot="joint")
-       
+            plot_pdf(
+                param_post,
+                expected_value=param_true,
+                compare_with=param_prior,
+                plot="joint",
+            )
+
         for i in range(2):
             posterior_mean = param_post.mean[i]
             posterior_std = param_post.std_diag[i]
 
             self.assertLess(posterior_std, 0.3)
-            self.assertAlmostEqual(posterior_mean, param_true[i], delta=2 * posterior_std)
-            
+            self.assertAlmostEqual(
+                posterior_mean, param_true[i], delta=2 * posterior_std
+            )
+
         post_noise_precision = noise_post[0].mean
-        post_noise_std = 1. / post_noise_precision**0.5
-        self.assertAlmostEqual(post_noise_std, noise_std, delta=noise_std/100)
-        
+        post_noise_sd = 1.0 / post_noise_precision ** 0.5
+        self.assertAlmostEqual(post_noise_sd, noise_sd, delta=noise_sd / 100)
+
         self.assertLess(info.nit, 20)
         print(info)
 
-    def test_vb_with_numeric_jac(self):
-        self.run_vb(n_data=1000, given_jac=False)
+    # def test_vb_with_numeric_jac(self):
+        # self.run_vb(n_data=1000, given_jac=False)
 
     def test_vb_with_given_jac(self):
         self.run_vb(n_data=1000, given_jac=True, plot=False)
 
+
 if __name__ == "__main__":
     import logging
+
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()

--- a/tests/test_vb.py
+++ b/tests/test_vb.py
@@ -20,7 +20,7 @@ class ForwardModel:
         return np.vstack([d_dm, d_dc]).T
 
 
-class ModelError(VariationalBayesModelError):
+class ModelError(VariationalBayesInterface):
     def __init__(self, forward_model, data):
         """
         forward_model:

--- a/tests/test_vb_ARD.py
+++ b/tests/test_vb_ARD.py
@@ -1,53 +1,59 @@
 import numpy as np
 import unittest
 from bayes.vb import *
-from test_vb import stack_data, ModelError, ModelErrorWithJacobian
+from test_vb import ModelError, ModelErrorWithJacobian
+
 
 class ForwardModel:
     def __init__(self):
-        self.xs = np.linspace(.0, 10, 20)
+        self.xs = np.linspace(0.0, 10, 20)
 
     def __call__(self, parameters):
         m = parameters[0]
         c = parameters[1]
         b = parameters[2:]
-        v = [c + x * m + b[i] for i, x in enumerate(self.xs)]
-        return np.array(v)
+        return c + self.xs * m + b
 
     def jacobian(self, parameters):
         m = parameters[0]
         c = parameters[1]
         b = parameters[2:]
 
-        d_dm = [x for x in self.xs]
-        d_dc = [1 for x in self.xs]
+        d_dm = self.xs
+        d_dc = np.ones_like(self.xs)
         all_d = [d_dm, d_dc]
         for i in b:
-            all_d.append([1 for x in self.xs] )
+            all_d.append([1 for x in self.xs])
 
         return np.array(all_d).T
 
+
 class Test_VB(unittest.TestCase):
-    '''
+    """
     Test having an ARD parameter (see Chappell paper for more info)
     True model (used for data generation) is defined as a linear model + bias term at each "sensor" location (xs)
     Bias term represents how the fw model deviates from the true model and should be inferred during VB. Since the bias parameters are sparse, an ARD prior is set for them.
-    '''
+    """
 
     def run_vb(self, n_data, given_jac=False, plot=False):
         np.random.seed(6174)
 
         fw = ForwardModel()
         n_sensors = len(fw.xs)
-        param_true = [7., 10.]
+        param_true = [7.0, 10.0]
 
-        bias_true = [0]*(n_sensors)
+        bias_true = [0] * (n_sensors)
         bias_true[3] = 5
         param_true = param_true + bias_true
-#        noise_std =0.1
-        noise_std = 0.01*abs(np.mean(fw(param_true)))
+        #        noise_std =0.1
+        noise_std = 0.01 * abs(np.mean(fw(param_true)))
 
-        data = stack_data(fw(param_true), n_data, noise_std)
+        data = []
+        perfect_data = fw(param_true)
+        for _ in range(n_data):
+            data.append(
+                perfect_data + np.random.normal(0, noise_std, len(perfect_data))
+            )
 
         if given_jac:
             me = ModelErrorWithJacobian(fw, data)
@@ -55,34 +61,54 @@ class Test_VB(unittest.TestCase):
             me = ModelError(fw, data)
 
         # setting mean and precision
-        bias_param = [[0]* n_sensors, [1e-3]* n_sensors]
-        param_prior = MVN([6, 11]+bias_param[0], ([1 / 3 ** 2, 1 / 3**2] + bias_param[1])*np.identity(2+n_sensors))
-        noise_prior = Gamma(s=0.5, c=2*1/noise_std**2)
+        bias_param = [[0] * n_sensors, [1e-3] * n_sensors]
+        param_prior = MVN(
+            [6, 11] + bias_param[0],
+            ([1 / 3 ** 2, 1 / 3 ** 2] + bias_param[1]) * np.identity(2 + n_sensors),
+        )
+        noise_prior = Gamma(s=0.5, c=2 * 1 / noise_std ** 2)
 
         vb = VB()
-        info = vb.run(me, param_prior, noise_prior, index_ARD=np.arange(2, n_sensors+2), iter_max=100, n_trials_max=50)
+        info = vb.run(
+            me,
+            param_prior,
+            noise_prior,
+            index_ARD=np.arange(2, n_sensors + 2),
+            iter_max=100,
+            n_trials_max=50,
+        )
         param_post, noise_post = info.param, info.noise
 
         if plot:
-            plot_pdf(param_post, expected_value=param_true, compare_with=param_prior, plot="joint")
+            plot_pdf(
+                param_post,
+                expected_value=param_true,
+                compare_with=param_prior,
+                plot="joint",
+            )
 
         for i, p in enumerate(param_true):
             if i < 2 or abs(p) > 1e-10:
                 posterior_mean = param_post.mean[i]
                 posterior_std = param_post.std_diag[i]
-                print("Param {} True value = {} ".format(i, param_true[i]), "\n inferred = {} +- {}".format(posterior_mean, posterior_std) )
-                #self.assertLess(posterior_std, 0.3)
-                self.assertAlmostEqual(posterior_mean, param_true[i], delta=2 * posterior_std)
+                print(
+                    "Param {} True value = {} ".format(i, param_true[i]),
+                    "\n inferred = {} +- {}".format(posterior_mean, posterior_std),
+                )
+                # self.assertLess(posterior_std, 0.3)
+                self.assertAlmostEqual(
+                    posterior_mean, param_true[i], delta=2 * posterior_std
+                )
 
-        post_noise_precision = noise_post[0].mean
-        post_noise_std = 1. / post_noise_precision ** 0.5
+        post_noise_precision = noise_post.mean
+        post_noise_std = 1.0 / post_noise_precision ** 0.5
         self.assertAlmostEqual(post_noise_std, noise_std, delta=noise_std / 100)
 
     # def test_vb_with_numeric_jac(self):
     #     self.run_vb(n_data=1000, given_jac=False, plot=True)
 
     def test_vb_with_given_jac(self):
-        self.run_vb(n_data=10,given_jac=False, plot=False)
+        self.run_vb(n_data=10, given_jac=False, plot=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_vb_ARD.py
+++ b/tests/test_vb_ARD.py
@@ -66,7 +66,7 @@ class Test_VB(unittest.TestCase):
             [6, 11] + bias_param[0],
             ([1 / 3 ** 2, 1 / 3 ** 2] + bias_param[1]) * np.identity(2 + n_sensors),
         )
-        noise_prior = Gamma(s=0.5, c=2 * 1 / noise_std ** 2)
+        noise_prior = Gamma(scale=0.5, shape=2 * 1 / noise_std ** 2)
 
         vb = VB()
         info = vb.run(

--- a/tests/test_vb_minimal.py
+++ b/tests/test_vb_minimal.py
@@ -8,11 +8,13 @@ A, B, sd = 7.0, 42.0, 0.1
 data = A * x + B + np.random.normal(0, sd, len(x))
 
 
-def me_list(parameters):
-    return [parameters[0] * x + parameters[1] - data]
+def me_dict(parameters):
+    return {"noise": parameters[0] * x + parameters[1] - data}
+
 
 def me_vector(parameters):
     return parameters[0] * x + parameters[1] - data
+
 
 class Test_VB(unittest.TestCase):
     def run_vb(self, model_error):
@@ -41,14 +43,14 @@ class Test_VB(unittest.TestCase):
                 posterior_mean, correct_value, delta=2 * posterior_std
             )
 
-        post_noise_precision = noise_post[0].mean
+        post_noise_precision = noise_post.mean
         post_noise_std = 1.0 / post_noise_precision ** 0.5
         self.assertAlmostEqual(post_noise_std, sd, delta=sd / 100)
 
         self.assertLess(info.nit, 20)
 
-    def test_list(self):
-        self.run_vb(me_list)
+    def test_dict(self):
+        self.run_vb(me_dict)
 
     def test_vector(self):
         self.run_vb(me_vector)

--- a/tests/test_vb_minimal.py
+++ b/tests/test_vb_minimal.py
@@ -20,7 +20,7 @@ class Test_VB(unittest.TestCase):
     def run_vb(self, model_error):
 
         param_prior = MVN([6, 11], [[1 / 3 ** 2, 0], [0, 1 / 3 ** 2]])
-        noise_prior = Gamma(s=0.1, c=1000)
+        noise_prior = Gamma(shape=0.1, scale=1000)
 
         info = variational_bayes(model_error, param_prior, noise_prior)
         param_post, noise_post = info.param, info.noise

--- a/tests/test_vb_stop.py
+++ b/tests/test_vb_stop.py
@@ -3,25 +3,27 @@ import numpy as np
 import unittest
 import logging
 from bayes.vb import VB
-logging.getLogger('matplotlib.font_manager').disabled = True
+
+logging.getLogger("matplotlib.font_manager").disabled = True
 logger = logging.getLogger(__name__)
 
 
 class TestFreeEnergy(unittest.TestCase):
-    np.random.seed(12345) # Seed the random number generator for reproducible results
+    np.random.seed(12345)  # Seed the random number generator for reproducible results
     # Location, scale and weight for the two distributions
-    dist1_loc, dist1_scale, weight1 = -1 , .5, .25
-    dist2_loc, dist2_scale, weight2 = 4 , 1.75, 1.75
-    dist3_loc, dist3_scale, weight3 = 9 , .5, .40
+    dist1_loc, dist1_scale, weight1 = -1, 0.5, 0.25
+    dist2_loc, dist2_scale, weight2 = 4, 1.75, 1.75
+    dist3_loc, dist3_scale, weight3 = 9, 0.5, 0.40
 
     # Sample from a mixture of distributions
-    param       = np.linspace(-2,12,500)
-    free_energy = (  stats.norm.pdf(loc=dist1_loc, scale=dist1_scale, x=param)*weight1
-                   + stats.norm.pdf(loc=dist2_loc, scale=dist2_scale, x=param)*weight2
-                   + stats.norm.pdf(loc=dist3_loc, scale=dist3_scale, x=param)*weight3)
+    param = np.linspace(-2, 12, 500)
+    free_energy = (
+        stats.norm.pdf(loc=dist1_loc, scale=dist1_scale, x=param) * weight1
+        + stats.norm.pdf(loc=dist2_loc, scale=dist2_scale, x=param) * weight2
+        + stats.norm.pdf(loc=dist3_loc, scale=dist3_scale, x=param) * weight3
+    )
 
-
-    '''        
+    r"""
                         __
                        /  \      __
          free energy  /    \    /  \
@@ -31,104 +33,124 @@ class TestFreeEnergy(unittest.TestCase):
          |  /                          \___
          |--------> param
           --------> iteration
-    
-    '''
+
+    """
 
     def test_no_change_in_free_energy(self):
-        '''
+        """
         f_new - f_old < tol
-        '''
+        """
         msg = "---------Test case: Free energy is decreasing -max nb of trials was reached------- "
         logger.info(msg)
         # define samples of param and free energy for each iteration
         sample_interval = 10
-        param_sample           = self.param[::sample_interval]
-        free_energy_sample     = self.free_energy[::sample_interval]
+        free_energy_sample = self.free_energy[::sample_interval]
 
-
-        inference = VB(n_trials_max = 10, tolerance= 1e-4, iter_max = len(free_energy_sample))
+        inference = VB(
+            n_trials_max=10, tolerance=1e-4, iter_max=len(free_energy_sample)
+        )
         for i_iter in range(inference.iter_max):
-            param_new = [param_sample[i_iter]]
-            f_new     = free_energy_sample[i_iter]
+            f_new = free_energy_sample[i_iter]
             if inference.stop_criteria(f_new, i_iter):
                 break
 
-        print(inference.f_stored, max(free_energy_sample),  inference.tolerance )
-        self.assertAlmostEqual(inference.f_stored, max(free_energy_sample), delta = inference.tolerance, msg = "iterations didn't go through the max in freee energy" )
-
+        print(inference.result.f_max, max(free_energy_sample), inference.tolerance)
+        self.assertAlmostEqual(
+            inference.result.f_max,
+            max(free_energy_sample),
+            delta=inference.tolerance,
+            msg="iterations didn't go through the max in freee energy",
+        )
 
     def test_increase_in_free_energy_at_max_iter(self):
-            '''
+        """
             f_new > f_old but i=iter_max
             :return:
-            '''
-            msg ="---------Test case: Free energy is increasing - max nb of iterations is reached ---------"
-            logger.info(msg)
-            # define samples of param and free energy for each iteration
-            sample_interval    = 1
-            param_sample       = self.param[::sample_interval]
-            free_energy_sample = self.free_energy[::sample_interval]
+            """
+        msg = "---------Test case: Free energy is increasing - max nb of iterations is reached ---------"
+        logger.info(msg)
+        # define samples of param and free energy for each iteration
+        sample_interval = 1
+        free_energy_sample = self.free_energy[::sample_interval]
 
-            inference = VB(n_trials_max = 100, tolerance= 1e-8, iter_max = 50)
-            for i_iter in range(inference.iter_max+100):
-                param_new = [param_sample[i_iter]]
-                f_new     = free_energy_sample[i_iter]
-                if inference.stop_criteria(param_new,f_new, i_iter):
-                    break
+        inference = VB(n_trials_max=100, tolerance=1e-8, iter_max=50)
+        for i_iter in range(inference.iter_max + 100):
+            f_new = free_energy_sample[i_iter]
+            if inference.stop_criteria(f_new, i_iter):
+                break
 
-            print(inference.f_stored, max(free_energy_sample),  inference.tolerance )
-            self.assertLessEqual(inference.f_stored, max(free_energy_sample), msg = "f_stored is cannot increase further")
-            self.assertEqual(inference.iter_max, i_iter)
-
+        print(inference.result.f_max, max(free_energy_sample), inference.tolerance)
+        self.assertLessEqual(
+            inference.result.f_max,
+            max(free_energy_sample),
+            msg="result.f_max is cannot increase further",
+        )
+        self.assertEqual(inference.iter_max, i_iter)
 
     def test_stopped_by_max_iter(self):
-            '''
+        """
             f_new < f_old but i=iter_max and n_trials<n_trials_max
             :return:
-            '''
-            msg = "---------Test case: Free energy is decreasing -max nb of iterations is reached before n_trials_max---------"
-            logger.info(msg)
-            # define samples of param and free energy for each iteration
-            sample_interval    = 1
-            param_sample       = self.param[::sample_interval]
-            free_energy_sample = self.free_energy[::sample_interval]
+            """
+        msg = "---------Test case: Free energy is decreasing -max nb of iterations is reached before n_trials_max---------"
+        logger.info(msg)
+        # define samples of param and free energy for each iteration
+        sample_interval = 1
+        free_energy_sample = self.free_energy[::sample_interval]
 
-            inference = VB(n_trials_max = 100, tolerance= 1e-5, iter_max = 250)
-            for i_iter in range(inference.iter_max):
-                param_new = [param_sample[i_iter]]
-                f_new     = free_energy_sample[i_iter]
-                if inference.stop_criteria(param_new,f_new, i_iter):
-                    break
+        inference = VB(n_trials_max=100, tolerance=1e-5, iter_max=250)
+        for i_iter in range(inference.iter_max):
+            f_new = free_energy_sample[i_iter]
+            if inference.stop_criteria(f_new, i_iter):
+                break
 
-            print(inference.f_stored, max(free_energy_sample),  inference.tolerance )
-            self.assertAlmostEqual(inference.f_stored, max(free_energy_sample), delta = inference.tolerance, msg = "iterations didn't go through the max in freee energy" )
-            self.assertLessEqual(inference.n_trials, inference.n_trials_max, msg = "n_trials_max was reached")
+        print(inference.result.f_max, max(free_energy_sample), inference.tolerance)
+        self.assertAlmostEqual(
+            inference.result.f_max,
+            max(free_energy_sample),
+            delta=inference.tolerance,
+            msg="iterations didn't go through the max in freee energy",
+        )
+        self.assertLessEqual(
+            inference.n_trials, inference.n_trials_max, msg="n_trials_max was reached"
+        )
 
     def test_reached_tolerance_return_stored(self):
-            '''
+        """
             f_new < f_old but i=iter_max and n_trials<n_trials_max
             :return:
-            '''
-            msg = "---------Test case: Free energy change is below tolerance - return stored param values---------T"
-            logger.info(msg)
-            # define samples of param and free energy for each iteration
-            sample_interval    = 10
-            param_sample       = self.param[::sample_interval]
-            free_energy_sample = self.free_energy[::sample_interval]
+            """
+        msg = "---------Test case: Free energy change is below tolerance - return stored param values---------T"
+        logger.info(msg)
+        # define samples of param and free energy for each iteration
+        sample_interval = 10
+        free_energy_sample = self.free_energy[::sample_interval]
 
-            inference = VB(n_trials_max = 100, tolerance= 5e-3, iter_max =len(param_sample))
-            for i_iter in range(inference.iter_max):
-                param_new = [param_sample[i_iter]]
-                f_new     = free_energy_sample[i_iter]
-                if inference.stop_criteria(param_new,f_new, i_iter):
-                    break
+        inference = VB(
+            n_trials_max=100, tolerance=5e-3, iter_max=len(free_energy_sample)
+        )
+        for i_iter in range(inference.iter_max):
+            f_new = free_energy_sample[i_iter]
+            if inference.stop_criteria(f_new, i_iter):
+                break
 
-            print(inference.f_stored, max(free_energy_sample),  inference.tolerance )
-            self.assertAlmostEqual(inference.f_old, f_new, delta = inference.tolerance, msg = "change in free energy is higher than tolerance" )
-            self.assertAlmostEqual(inference.f_stored, max(free_energy_sample), delta = inference.tolerance, msg = "f_stored didnt reach max free energy ")
+        print(inference.result.f_max, max(free_energy_sample), inference.tolerance)
+        self.assertAlmostEqual(
+            inference.f_old,
+            f_new,
+            delta=inference.tolerance,
+            msg="change in free energy is higher than tolerance",
+        )
+        self.assertAlmostEqual(
+            inference.result.f_max,
+            max(free_energy_sample),
+            delta=inference.tolerance,
+            msg="result.f_max didnt reach max free energy ",
+        )
 
 
 if __name__ == "__main__":
     import logging
+
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()

--- a/tests/test_vb_stop.py
+++ b/tests/test_vb_stop.py
@@ -50,7 +50,7 @@ class TestFreeEnergy(unittest.TestCase):
         for i_iter in range(inference.iter_max):
             param_new = [param_sample[i_iter]]
             f_new     = free_energy_sample[i_iter]
-            if inference.stop_criteria(param_new,f_new, i_iter):
+            if inference.stop_criteria(f_new, i_iter):
                 break
 
         print(inference.f_stored, max(free_energy_sample),  inference.tolerance )


### PR DESCRIPTION
* Try to entangle different model error definitions:
    * `ModelErrorInterface` as an interface for the `InferenceProblem`
    * `VariationalBayesModelError` as an interface for VB
    * see the `__call__` documentation for the differences
* Adapt VB algorithm to a dict of noise groups:
    * the VBModelError needs to return a `dict {noise_key : numbers}`
    * its jacobian must return `dict {noise_key : matrix}`
    * the noise prior must be `dict {noise_key : Gamma}`
    * A VBAdapter lets you use `numbers, matrix, Gamma` (for error, jacobian, noise prior respectively) for the simple cases of only one noise group. 
* provide `jacobian.py` to collect algorithms to calculate the Jacobian via central differences for
    * single named scalar parameter
    * single named vector parameter
    * unnamed normal list of numbers
