### PR TITLE
Add optional parameter_names to MVN

### DIFF
--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -218,4 +218,4 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesInterface):
                 means.append(mean)
                 precs.append(1.0 / sd ** 2)
 
-        return MVN(means, np.diag(precs))
+        return MVN(means, np.diag(precs), name="MVN prior", parameter_names=list(self.latent.keys()))

--- a/tests/test_MVN.py
+++ b/tests/test_MVN.py
@@ -1,0 +1,35 @@
+import unittest
+import numpy as np
+from bayes.vb import MVN
+
+
+class TestMVN(unittest.TestCase):
+    def setUp(self):
+        self.mvn = MVN(
+            mean=np.r_[1, 2, 3],
+            precision=np.diag([1, 2, 3]),
+            parameter_names=["A", "B", "C"],
+        )
+
+    def test_named_print(self):
+        print(self.mvn)
+
+    def test_named_access(self):
+        self.assertEqual(self.mvn.index("A"), 0)
+        self.assertEqual(self.mvn.named_mean("A"), 1)
+        self.assertEqual(self.mvn.named_sd("A"), 1)
+
+    def test_dim_mismatch(self):
+        mean2 = np.random.random(2)
+        prec2 = np.random.random((2, 2))
+        prec3 = np.random.random((3, 3))
+        with self.assertRaises(Exception):
+            MVN(mean2, prec3)
+
+        MVN(mean2, prec2)  # no exception!
+        with self.assertRaises(Exception):
+            MVN(mean2, prec2, parameter_names=["A", "B", "C"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If you provide the additional argument `parameter_names` (e.g. `["A1", "B1", "A2", "B2"]` in one test case) to `bayes.vb.MVN`, the `__str__` method now returns

~~~
  param:         MVN posterior with 
                  ├── A1 µ=100.688020 σ=  0.819414 
                  ├── B1 µ=199.706033 σ=  0.481305 
                  ├── A2 µ=301.032772 σ=  0.819414 
                  ├── B2 µ=400.063915 σ=  0.481305 
~~~

instead of 
~~~
  param:         MVN with 
                  ├── mean: [ 1.007e+02  1.997e+02  3.010e+02  4.001e+02]
                  ├── std:  [ 8.194e-01  4.813e-01  8.194e-01  4.813e-01]
~~~

You can also access the individual parameters via 
~~~py
mvn.named_mean("A1")  # = 100.688020
mvn.named_sd("B2") # = 0.481305 
~~~
