### PR TITLE
Swapping plus and minus here and there. Fixes #19

### DIFF
--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -179,7 +179,7 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesInterface):
                     if len(J.shape) == 1:
                         J = np.atleast_2d(J).T
 
-                    stacked_jac[:, self.latent[global_name].global_index_range()] -= J
+                    stacked_jac[:, self.latent[global_name].global_index_range()] += J
 
                 sensor_jac[sensor] = stacked_jac
 

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -160,7 +160,7 @@ class VariationalBayesInterface:
                     jac[key] = np.empty([len(f0), len(x)])
 
             for n in fs0:
-                jac[n][:, iParam] = -(fs1[n] - fs0[n]) / (2 * dx)
+                jac[n][:, iParam] = (fs1[n] - fs0[n]) / (2 * dx)
 
         return jac
 
@@ -211,6 +211,8 @@ def variational_bayes(model_error, param0, noise0=None, **kwargs):
 
         jacobian(parameter_means) [optional]:
             * total jacobian of the forward model w.r.t. the parameters
+            * NOTE: This is differs from the definition in the Chapell paper
+                    where it is defined as MINUS d(forward_model)/d(parameters)
             * list of numpy matrices where each list corresponds to one noise group
             * alternatively: just a numpy matrix for the case of exactly one
                              noise group
@@ -359,7 +361,7 @@ class VB:
             L = sum([s[i] * c[i] * J[i].T @ J[i] for i in noise0]) + L0
             L_inv = np.linalg.inv(L)
 
-            Lm = sum([s[i] * c[i] * J[i].T @ (k[i] + J[i] @ m) for i in noise0])
+            Lm = sum([s[i] * c[i] * J[i].T @ (-k[i] + J[i] @ m) for i in noise0])
             Lm += L0 @ m0
             m = Lm @ L_inv
 

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -135,7 +135,7 @@ class TestJacobianJointGlobal(unittest.TestCase):
 
         J = p.jacobian([42.0])[noise_key]
         self.assertEqual(J.shape, (6, 1))
-        CHECK(J[:, 0], -me.x_odd - me.x_even - me.x_all)
+        CHECK(J[:, 0], me.x_odd + me.x_even + me.x_all)
 
     def test_two_joints(self):
         """
@@ -150,7 +150,7 @@ class TestJacobianJointGlobal(unittest.TestCase):
         noise_key = p.add_noise_model(SingleSensorNoise())
 
         J = p.jacobian([42.0])[noise_key]
-        CHECK(J[:, 0], -me.x_odd - me.x_even)
+        CHECK(J[:, 0], me.x_odd + me.x_even)
 
 
 if __name__ == "__main__":

--- a/tests/test_vb.py
+++ b/tests/test_vb.py
@@ -42,7 +42,7 @@ class ModelError(VariationalBayesInterface):
 
 class ModelErrorWithJacobian(ModelError):
     def jacobian(self, parameters):
-        jac = -self._forward_model.jacobian(parameters)
+        jac = self._forward_model.jacobian(parameters)
         full_jac = np.tile(jac, (len(self._data), 1))
         return {"noise0": full_jac}
 


### PR DESCRIPTION
When we ignore all that `k(theta) = (model(theta) - data)` vs `k(theta) = (data - model(theta))` stuff, the Chapell paper basically defines the Jacobian J as `J = - dk / dtheta`, which can be confusing. Also it was documented incorrectly in our code. 

This PR changes this definition to `J = dk / dtheta`.