### PR TITLE
Fix error in loglike

### DIFF
--- a/bayes/noise.py
+++ b/bayes/noise.py
@@ -85,19 +85,10 @@ class UncorrelatedNoiseModel(NoiseModelInterface):
         """
         terms = self.model_error_terms(model_error_dict)
         prec = self.parameter_list["precision"]
-        # sigma = 1.0 / self.parameter_list["precision"] ** 0.5
         ll = 0.0
         for error in terms:
-            N = len(error)
-            ll -= N/2 * math.log(2*math.pi)
-            ll -= N/2 * math.log(1/prec)
+            ll -= len(error)/2 * math.log(2*math.pi/prec)
             ll -= 0.5 * prec * np.sum(np.square(error))
-
-
-            # ll += -0.5 * (
-                # len(error) * np.log(2.0 * np.pi / prec)
-                # + np.sum(np.square(error))*prec
-            # )
         return ll
 
     def _by_noise(self, dict_of_dicts):

--- a/bayes/noise.py
+++ b/bayes/noise.py
@@ -1,5 +1,6 @@
 import numpy as np
 from .parameters import ParameterList
+import math
 
 """
 The inference problem provides:
@@ -83,13 +84,20 @@ class UncorrelatedNoiseModel(NoiseModelInterface):
         overwritten
         """
         terms = self.model_error_terms(model_error_dict)
-        sigma = 1.0 / self.parameter_list["precision"] ** 0.5
+        prec = self.parameter_list["precision"]
+        # sigma = 1.0 / self.parameter_list["precision"] ** 0.5
         ll = 0.0
         for error in terms:
-            ll += -0.5 * (
-                len(error) * np.log(2.0 * np.pi * sigma ** 2)
-                + np.sum(np.square(error / sigma ** 2))
-            )
+            N = len(error)
+            ll -= N/2 * math.log(2*math.pi)
+            ll -= N/2 * math.log(1/prec)
+            ll -= 0.5 * prec * np.sum(np.square(error))
+
+
+            # ll += -0.5 * (
+                # len(error) * np.log(2.0 * np.pi / prec)
+                # + np.sum(np.square(error))*prec
+            # )
         return ll
 
     def _by_noise(self, dict_of_dicts):

--- a/tests/sampling_example.py
+++ b/tests/sampling_example.py
@@ -119,14 +119,14 @@ if __name__ == "__main__":
     problem.set_normal_prior("B", 6000.0, 300.0)
 
     noise1 = UncorrelatedNoiseModel()
-    noise1.add(s1, key1)
-    noise1.add(s2, key1)
-    noise1.add(s3, key1)
+    noise1.add(key1, s1)
+    noise1.add(key1, s2)
+    noise1.add(key1, s3)
 
     noise2 = UncorrelatedNoiseModel()
-    noise2.add(s1, key2)
-    noise2.add(s2, key2)
-    noise2.add(s3, key2)
+    noise2.add(key2, s1)
+    noise2.add(key2, s2)
+    noise2.add(key2, s3)
 
     noise_key1 = problem.add_noise_model(noise1)
     noise_key2 = problem.add_noise_model(noise2)


### PR DESCRIPTION
In the current implementation I (I think) introduced a bug in the loglike_contribution that was like
~~~
+ np.sum(np.square(error / sigma ** 2))
~~~
so sigma**2 _within_ a np.square.

I reformulated the definition to use the precision and provided a test against `scipy.stats.norm.logpdf(terms)`.