### PR TITLE
Json serialize

### DIFF
--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -84,7 +84,7 @@ class Gamma:
         return scipy.stats.gamma.pdf(xs, a=self.shape, scale=self.scale)
 
     def __repr__(self):
-        return f"{self.name} with \n └── mean: {self.mean, 9}"
+        return f"{self.name} with \n └── mean: {self.mean:10.6f}"
 
     @classmethod
     def FromSD(cls, sd, shape=1.0):
@@ -99,29 +99,6 @@ class Gamma:
         https://math.stackexchange.com/questions/449234/vague-gamma-prior
         """
         return cls(scale=1.0 / 3.0, shape=0.0)
-
-
-class BayesEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, MVN):
-            return {"vb.MVN": obj.__dict__}
-        if isinstance(obj, Gamma):
-            return {"vb.Gamma": obj.__dict__}
-        if isinstance(obj, np.ndarray):
-            return {"np.array": obj.tolist()}
-        return json.JSONEncoder.default(self, obj)
-
-
-def bayes_hook(dct):
-    if "vb.MVN" in dct:
-        d = dct["vb.MVN"]
-        return MVN(d["mean"], d["precision"], d["name"], d["parameter_names"])
-    if "vb.Gamma" in dct:
-        d = dct["vb.Gamma"]
-        return Gamma(d["shape"], d["scale"], d["name"])
-    if "np.array" in dct:
-        return np.array(dct["np.array"])
-    return dct
 
 
 def plot_pdf(
@@ -520,3 +497,88 @@ class VB:
         # go on.
         self.f_old = f_new
         return False
+
+
+class BayesEncoder(json.JSONEncoder):
+    """
+    Usage:
+        string = json.dumps(obj, cls=bayes.vb.BayesEncoder, ...)
+        with open(...) as f:
+            json.dump(obj, f cls=bayes.vb.BayesEncoder, ...)
+
+    Details:
+
+    Out of the box, JSON can serialize 
+        dict, list, tuple, str, int, float, True/False, None
+    
+    To make our custom classes JSON serializable, we subclass from JSONEncoder
+    and overwrite its `default` method to somehow represent our class with the
+    types provided above.
+
+    The idea is to serialize our custom classes (and numpy...) as a dict 
+    containing:
+        key: unique string to represent the classe -- this helps us to indentify
+             the class when _de_serializing in `bayes.vb.bayes_hook` below
+        value: some json-serializable entries -- obj.__dict__ contains all 
+               members class members and is not optimal, but very convenient.
+    https://stackoverflow.com/questions/3768895/how-to-make-a-class-json-serializable
+
+    Note that the method is called recursively. To serialize MVN we call the
+    `default` method below and see that json representation should contain
+    the __dict__ of members. This dict also contains "mean" of type `np.array`.
+    Thus, `default` is now called on `np.array` which is represented by a list
+    of its values.
+
+    """
+
+    def default(self, obj):
+        if isinstance(obj, VBResult):
+            return {"vb.VBResult": obj.__dict__}
+
+        if isinstance(obj, MVN):
+            return {"vb.MVN": obj.__dict__}
+
+        if isinstance(obj, Gamma):
+            return {"vb.Gamma": obj.__dict__}
+
+        if isinstance(obj, np.ndarray):
+            return {"np.array": obj.tolist()}
+
+        # `obj` is not one of our types? Fall back to superclass implementation.
+        return json.JSONEncoder.default(self, obj)
+
+
+def bayes_hook(dct):
+    """
+    Usage:
+        obj = json.loads(string, object_hook=bayes.vb.bayes_hook, ...)
+        with open(...) as f:
+            obj = json.load(f, object_hook=bayes.vb.bayes_hook, ...)
+
+    Details:
+
+    BayesEncoder stores all of our classes as dicts containing their members.
+    This `object_hook` tries to convert those dicts back to actual python objects.
+
+    Some fancy metaprogramming may help to avoid repetition. TODO?
+    """
+    if "vb.VBResult" in dct:
+        result = VBResult()
+        result.__dict__ = dct["vb.VBResult"]
+        return result
+
+    if "vb.MVN" in dct:
+        mvn = MVN()
+        mvn.__dict__ = dct["vb.MVN"]
+        return mvn
+
+    if "vb.Gamma" in dct:
+        gamma = Gamma()
+        gamma.__dict__ = dct["vb.Gamma"]
+        return gamma
+
+    if "np.array" in dct:
+        return np.array(dct["np.array"])
+
+    # Type not recognized, just return the dict.
+    return dct

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -109,7 +109,7 @@ class BayesEncoder(json.JSONEncoder):
             return {"vb.Gamma": obj.__dict__}
         if isinstance(obj, np.ndarray):
             return {"np.array": obj.tolist()}
-        return JSONEncoder.default(self, obj)
+        return json.JSONEncoder.default(self, obj)
 
 
 def bayes_hook(dct):

--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -532,6 +532,12 @@ class BayesEncoder(json.JSONEncoder):
     """
 
     def default(self, obj):
+        """
+        `obj`:
+            python object to serialize
+        return:
+            json (serializeable) reprensentation of `obj`
+        """
         if isinstance(obj, VBResult):
             return {"vb.VBResult": obj.__dict__}
 
@@ -550,6 +556,11 @@ class BayesEncoder(json.JSONEncoder):
 
 def bayes_hook(dct):
     """
+    `dct`:
+        json reprensentation of an `obj` (a dict)
+    `obj`:
+        python object created from `dct`
+
     Usage:
         obj = json.loads(string, object_hook=bayes.vb.bayes_hook, ...)
         with open(...) as f:

--- a/tests/test_MVN.py
+++ b/tests/test_MVN.py
@@ -35,6 +35,7 @@ class TestMVN(unittest.TestCase):
         data = {}
         data["parameter_prior"] = self.mvn
         data["noise_prior"] = bayes.vb.Gamma()
+        data["non bayes thing"] = {"best number": 6174.0}
 
         string = json.dumps(data, cls=bayes.vb.BayesEncoder, indent=2)
         print(string)

--- a/tests/test_MVN.py
+++ b/tests/test_MVN.py
@@ -36,9 +36,8 @@ class TestMVN(unittest.TestCase):
         data["parameter_prior"] = self.mvn
         data["noise_prior"] = bayes.vb.Gamma()
 
-        string = json.dumps(data, cls=bayes.vb.BayesEncoder)
-
-        # print(string)
+        string = json.dumps(data, cls=bayes.vb.BayesEncoder, indent=2)
+        print(string)
 
         loaded = json.loads(string, object_hook=bayes.vb.bayes_hook)
 

--- a/tests/test_MVN.py
+++ b/tests/test_MVN.py
@@ -1,7 +1,6 @@
 import unittest
 import numpy as np
 import bayes.vb
-import json
 
 
 class TestMVN(unittest.TestCase):
@@ -30,29 +29,6 @@ class TestMVN(unittest.TestCase):
         bayes.vb.MVN(mean2, prec2)  # no exception!
         with self.assertRaises(Exception):
             bayes.vb.MVN(mean2, prec2, parameter_names=["A", "B", "C"])
-
-    def test_json(self):
-        data = {}
-        data["parameter_prior"] = self.mvn
-        data["noise_prior"] = bayes.vb.Gamma()
-        data["non bayes thing"] = {"best number": 6174.0}
-
-        string = json.dumps(data, cls=bayes.vb.BayesEncoder, indent=2)
-        print(string)
-
-        loaded = json.loads(string, object_hook=bayes.vb.bayes_hook)
-
-        A, B = data["parameter_prior"], loaded["parameter_prior"]
-        CHECK = np.testing.assert_array_equal
-        self.assertEqual(A.name, B.name)
-        self.assertEqual(A.parameter_names, B.parameter_names)
-        CHECK(A.mean, B.mean)
-        CHECK(A.precision, B.precision)
-
-        C, D = data["noise_prior"], loaded["noise_prior"]
-        self.assertEqual(C.name, D.name)
-        self.assertEqual(C.shape, D.shape)
-        self.assertEqual(C.scale, D.scale)
 
 
 if __name__ == "__main__":

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,38 @@
+import unittest
+import numpy as np
+import bayes.vb
+import json
+
+
+class TestJSON(unittest.TestCase):
+    def test_json(self):
+        data = {}
+        data["parameter_prior"] = bayes.vb.MVN(
+            mean=np.r_[1, 2, 3],
+            precision=np.diag([1, 2, 3]),
+            parameter_names=["A", "B", "C"],
+        )
+
+        data["noise_prior"] = bayes.vb.Gamma()
+        data["non bayes thing"] = {"best number": 6174.0}
+
+        string = json.dumps(data, cls=bayes.vb.BayesEncoder, indent=2)
+        print(string)
+
+        loaded = json.loads(string, object_hook=bayes.vb.bayes_hook)
+
+        A, B = data["parameter_prior"], loaded["parameter_prior"]
+        CHECK = np.testing.assert_array_equal
+        self.assertEqual(A.name, B.name)
+        self.assertEqual(A.parameter_names, B.parameter_names)
+        CHECK(A.mean, B.mean)
+        CHECK(A.precision, B.precision)
+
+        C, D = data["noise_prior"], loaded["noise_prior"]
+        self.assertEqual(C.name, D.name)
+        self.assertEqual(C.shape, D.shape)
+        self.assertEqual(C.scale, D.scale)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -33,6 +33,22 @@ class TestJSON(unittest.TestCase):
         self.assertEqual(C.shape, D.shape)
         self.assertEqual(C.scale, D.scale)
 
+    def test_vb_result(self):
+        def dummy_me(prm):
+            return prm ** 2
+
+        result = bayes.vb.variational_bayes(
+            dummy_me,
+            param0=bayes.vb.MVN([1, 1], np.diag([1, 1]), parameter_names=["A", "B"]),
+        )
+
+        dumped = json.dumps(result, cls=bayes.vb.BayesEncoder, indent=2)
+
+        loaded = json.loads(dumped, object_hook=bayes.vb.bayes_hook)
+        dumped_again = json.dumps(loaded, cls=bayes.vb.BayesEncoder, indent=2)
+
+        self.assertEqual(dumped, dumped_again)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
By default, `bayes.vb.MVN` and `bayes.vb.Gamma` are not serializable with JSON. This PR provides a matching encoder and decoder to enable this. 

IMO this is very handy when you want to easily read and write intermediate results to disk, e.g. in a pydoit-workflow where the posterior from one experiment is the prior of a subsequent one.