### PR TITLE
Scaled vb

### DIFF
--- a/bayes/inference_problem.py
+++ b/bayes/inference_problem.py
@@ -122,9 +122,9 @@ class VariationalBayesProblem(InferenceProblem, VariationalBayesInterface):
             )
         self.noise_prior[name] = gamma
 
-    def run(self):
+    def run(self, **kwargs):
         MVN = self.prior_MVN()
-        info = variational_bayes(self, MVN, self.noise_prior)
+        info = variational_bayes(self, MVN, self.noise_prior, **kwargs)
         return info
 
     def jacobian(self, number_vector, concatenate=True):

--- a/bayes/latent.py
+++ b/bayes/latent.py
@@ -165,7 +165,7 @@ class LatentParameter(list):
 
 class LatentParameters(OrderedDict):
     def update(self, number_vector):
-        n_parameters = sum(l.N for l in self.values())
+        n_parameters = self.N
         if n_parameters != len(number_vector):
             raise RuntimeError(
                 f"Dimension mismatch: There are {n_parameters} global parameters, but you provided {len(number_vector)}!"
@@ -173,6 +173,13 @@ class LatentParameters(OrderedDict):
 
         for latent in self.values():
             latent.update(number_vector)
+
+    @property
+    def N(self):
+        """
+        Returns the total number of latent parameters.
+        """
+        return sum(l.N for l in self.values())
 
     def __missing__(self, latent_name):
         """

--- a/bayes/latent.py
+++ b/bayes/latent.py
@@ -165,7 +165,7 @@ class LatentParameter(list):
 
 class LatentParameters(OrderedDict):
     def update(self, number_vector):
-        n_parameters = self.N
+        n_parameters = self.vector_length
         if n_parameters != len(number_vector):
             raise RuntimeError(
                 f"Dimension mismatch: There are {n_parameters} global parameters, but you provided {len(number_vector)}!"
@@ -175,9 +175,10 @@ class LatentParameters(OrderedDict):
             latent.update(number_vector)
 
     @property
-    def N(self):
+    def vector_length(self):
         """
-        Returns the total number of latent parameters.
+        Returns the total number of latent parameters, considering vector 
+        valued ones.
         """
         return sum(l.N for l in self.values())
 

--- a/tests/test_latent.py
+++ b/tests/test_latent.py
@@ -90,7 +90,7 @@ class TestLatentParameters(unittest.TestCase):
         v = latent.get_vector({"shared": 42})
 
         self.assertEqual(len(v), 5)
-        self.assertEqual(latent.N, 5)
+        self.assertEqual(latent.vector_length, 5)
 
 
 if __name__ == "__main__":

--- a/tests/test_latent.py
+++ b/tests/test_latent.py
@@ -89,6 +89,9 @@ class TestLatentParameters(unittest.TestCase):
         # Provinding a default value for that case is fine though:
         v = latent.get_vector({"shared": 42})
 
+        self.assertEqual(len(v), 5)
+        self.assertEqual(latent.N, 5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vb.py
+++ b/tests/test_vb.py
@@ -65,9 +65,11 @@ class Test_VB(unittest.TestCase):
             me = ModelError(fw, data)
 
         param_prior = MVN([6, 11], [[1 / 3 ** 2, 0], [0, 1 / 3 ** 2]])
-        noise_prior = {"noise0": Gamma.FromSD(3*noise_sd)}
+        noise_prior = {"noise0": Gamma.FromSD(3 * noise_sd)}
 
-        info = variational_bayes(me, param_prior, noise_prior)
+        info = variational_bayes(
+            me, param_prior, noise_prior, scale_by_prior_mean=given_jac
+        )
         param_post, noise_post = info.param, info.noise
 
         if plot:


### PR DESCRIPTION
In my bridge example, I have Young's modulus parameters that (because of SI units) are in the order of E~10⁹. Thus, their precision is in the order of 10⁻¹⁸. I realized that this causes numerical problems, especially if mixed with parameters with order 10⁻³ or so. The algorithm did not converge. 

Thus, I often manually change my parameter to E = E_factor * 10⁹ where I now infer E_factor. IMO this step could be done automatically within VB. So I tried scaling the parameter MVN by the prior mean -- only if the prior mean is not close to zero -- and it seems to work. Then, before returning the posterior MVN, I scale it back. 

Opinions on that? Should this be a default part of the algorithm? Should it be an option?