### PR TITLE
Add vb.scaling_eps to control when to apply scale

### DIFF
--- a/bayes/vb.py
+++ b/bayes/vb.py
@@ -331,6 +331,7 @@ class VB:
         self.iter_max = iter_max
         self.scale_by_prior_mean = True
         self.result = VBResult()
+        self.scaling_eps = 1.e-20
 
     def run(self, model_error, param0, noise0=None, **kwargs):
 
@@ -342,6 +343,8 @@ class VB:
             self.n_trials_max = kwargs["n_trials_max"]
         if "scale_by_prior_mean" in kwargs:
             self.scale_by_prior_mean = kwargs["scale_by_prior_mean"]
+        if "scaling_eps" in kwargs:
+            self.scaling_eps = kwargs["scaling_eps"]
 
         if not isinstance(model_error, VariationalBayesInterface):
             model_error = VBModelErrorWrapper(model_error)
@@ -352,7 +355,7 @@ class VB:
 
         if self.scale_by_prior_mean:
             for i, mean in enumerate(param0.mean):
-                if abs(mean) > 1:
+                if abs(mean) > self.scaling_eps:
                     scaling[i] = mean
 
         logger.debug(f"Using scaling {scaling}")

--- a/tests/test_vb.py
+++ b/tests/test_vb.py
@@ -64,7 +64,7 @@ class Test_VB(unittest.TestCase):
         else:
             me = ModelError(fw, data)
 
-        param_prior = MVN([6, 11], [[1 / 3 ** 2, 0], [0, 1 / 3 ** 2]])
+        param_prior = MVN([0, 11], [[1 / 7 ** 2, 0], [0, 1 / 3 ** 2]])
         noise_prior = {"noise0": Gamma.FromSD(3 * noise_sd)}
 
         info = variational_bayes(


### PR DESCRIPTION
Previously, the scaling was only applied to parameters with mean > 1. This `1` is now replaced by `scaling_eps = 1.e-20` (and adjustable via kwargs) to also affect parameters with numerically small means.
Generally, this is quite hacky. An alternative can be discussed here #47 