### PR TITLE
Use only exp kernel. Rewrite vb with C_inv

### DIFF
--- a/bayem/correlation.py
+++ b/bayem/correlation.py
@@ -1,107 +1,45 @@
-"""
-Created on Mon Dec 13 2021
-
-@author: ajafari
-"""
-
 import numpy as np
-# from numba import jit
-# from scipy.linalg.blas import dgemm, dsyrk, dtrsm
-# from scipy.linalg.lapack import dpotrf, dpttrf
-from scipy.spatial.distance import pdist, squareform
+from scipy.linalg import block_diag
 
 
-def correlation_matrix(x_mx, correlation_func, distance_metric="euclidean"):
+def correlation_matrix(x, l, N_blocks=1):
     """
-    Statistical correlation matrix between measurement points based on their distance.
+    Builds a dense correlation matrix C with exponential kernel. For `N_blocks > 1`,
+    a block matrix is returned with the only C as diagonal blocks.
 
-    Args:
-        x_mx: the coordinates of the measurement points between which the correlation
-            matrix is calculated, (N,K).
-        correlation_func: a callable for the kernel function that calculates the statistical correlation
-            between measurements made at two points that are `d` units distant from
-            each other, r_major^m -> r_major^m.
-        distance_metric: The distance metric to use. The distance function is the
-            same as the `metric` input argument of `scipy.spatial.distance.pdist`.
-
-    Returns:
-        rho_mx: correlation matrix.
+    x:
+        1D array of locations
+    l:
+        correlation length
+    N_blocks:
+        number of uncorrelated blocks
     """
-    if len(x_mx.shape)!=2:
-        raise ValueError('The input coordinates x_mx must be a 2-D array.')
-    d = squareform(pdist(x_mx, metric=distance_metric))
-    rho_mx = correlation_func(d)
+    loc = np.atleast_1d(x)
+    assert len(loc.shape) == 1
+    c0 = np.repeat([x], len(x), axis=0)
+    r = c0 - c0.T
+    C = np.exp(-abs(r) / l)
 
-    return rho_mx
+    diagonal_blocks = [C] * N_blocks
+    return block_diag(*diagonal_blocks)
 
-class CorrelationFunction:
-    def __init__(self, correlation_length, function_type="exponential", exponent=2):
-        """
-        Statistical correlation between measurements made at two points that are at `d`
-        units distance from each other.
-        Args:
-            correlation_length: `1/correlation_length` controls the strength of
-                correlation between two points. `correlation_length = 0` => complete
-                independence for all point pairs (`rho=0`). `correlation_length = Inf` =>
-                full dependence for all point pairs (`rho=1`).
-            function_type: name of the correlation function.
-            exponent: exponent in the type="cauchy" function. The larger the exponent the
-                less correlated two points are.
-        """
-        if correlation_length < 0:
-            raise ValueError("correlation_length must be a non-negative number.")
-        self.correlation_length = correlation_length
-        self.function_type = function_type.lower()
-        self.exponent = exponent
-    
-    def __call__(self, d):
-        """
-        d: distance(s) between points.
-        Returns:
-            rho: correlation coefficient for each element of `d`.
-        """
-        if np.any(d < 0):
-            raise ValueError("All elements of d must be non-negative numbers.")
-    
-        if self.correlation_length == 0:
-            idx = d == 0
-            rho = np.zeros(d.shape)
-            rho[idx] = 1
-        elif self.correlation_length == np.inf:
-            rho = np.ones(d.shape)
-        else:
-            if self.function_type == "exponential":
-                rho = np.exp(-d / self.correlation_length)
-            elif self.function_type == "cauchy":
-                rho = (1 + (d / self.correlation_length) ** 2) ** -self.exponent
-            elif self.function_type == "gaussian":
-                rho = np.exp(-((d / self.correlation_length) ** 2))
-            else:
-                raise ValueError(
-                    "Unknown function_type. It must be one of these: 'exponential', "
-                    "'cauchy', 'gaussian'."
-                )
-        return rho
 
-def inv_cov_vec_1D(coord_x, l_corr, _return_sparse=True, N_blocks=1, std=None):
+def inv_correlation_matrix(x, l, N_blocks=1, return_sparse=True):
     """
-    Calculates diagonal and off diagonal vectors of the tridiagonal inverse exponential
-    covariance matrix
+    Calculates the inverse of an exponential correlation matrix analytically.
+    This inverse has a tridiagonal structure and is taken from [1].
 
-    Utility function for 2D loglikelihood evaluation. Given vectors of space
-    and time points and the exponential covariance parameters returns the
-    diagonal and off diagonal vectors of the tridiagonal inverse space and time
-    covariance matrices. The expressions in [1] are modified to account for
-    vector standard deviations.
-
-    Args:
-        coord_x: Vector of x
-        l_corr: Correlation length in x
-        std: Modeling uncertainty std dev or c.o.v. in x
-
-    Returns:
-        C_0: Main diagonal vector of inverse covariance matrix
-        C_1: Off diagonal vector of inverse covariance matrix
+    x:
+        1D array of locations
+    l:
+        correlation length
+    N_blocks:
+        number of uncorrelated blocks
+    return_sparse:
+        If true, returns a sparse matrix with the results. If false, returns a
+        tuple (C_0, C_1) with
+            C_0: Main diagonal vector of inverse covariance matrix
+            C_1: Off diagonal vector of inverse covariance matrix
 
     References:
         [1] Parameter Estimation for the Spatial Ornstein-Uhlenbeck
@@ -109,45 +47,30 @@ def inv_cov_vec_1D(coord_x, l_corr, _return_sparse=True, N_blocks=1, std=None):
         https://dc.uwm.edu/cgi/viewcontent.cgi?article=2131&context=etd
     """
 
-    Nx = len(coord_x)
-    a = np.exp(-np.diff(coord_x) / l_corr)
-    if std is None:
-        std = np.ones(Nx)
+    Nx = len(x)
+    a = np.exp(-np.diff(x) / l)
 
     # Initialize arrays
     C_0 = np.zeros(Nx)
 
     # Diagonal and off diagonal elements
-    a11 = (1 / (1 - a[0] ** 2)) / std[0] ** 2
-    ann = (1 / (1 - a[-1] ** 2)) / std[-1] ** 2
-    aii = (1 / (1 - a[:-1] ** 2) + 1 / (1 - a[1:] ** 2) - 1) / std[1:-1] ** 2
+    a11 = 1 / (1 - a[0] ** 2)
+    ann = 1 / (1 - a[-1] ** 2)
+    aii = 1 / (1 - a[:-1] ** 2) + 1 / (1 - a[1:] ** 2) - 1
 
     # Assemble the diagonal vectors
     C_0[0] = a11
     C_0[1:-1] = aii
     C_0[-1] = ann
-    C_1 = (-a / (1 - a ** 2)) / (std[:-1] * std[1:])
-    
-    if _return_sparse:
+    C_1 = -a / (1 - a ** 2)
+
+    if return_sparse:
         CN0 = np.tile(C_0, N_blocks)
         CN1 = np.zeros(len(CN0) - 1)
         for i in range(N_blocks):
             CN1[i * Nx : (i + 1) * Nx - 1] = C_1
         from scipy.sparse import diags
+
         return diags([CN1, CN0, CN1], [-1, 0, 1])
     else:
         return C_0, C_1
-
-if __name__ == "__main__":
-    N = 100
-    L = 2
-    xs = np.linspace(1, L, N).reshape((N,1))
-    correlation_level = 3
-    correlation_length = correlation_level*L/N
-    kernel = CorrelationFunction(correlation_length=correlation_length)
-    M = correlation_matrix(xs, correlation_func=kernel)
-    M_inv = inv_cov_vec_1D(xs.flatten(), correlation_length)
-    
-    assert np.linalg.norm(M_inv@M - np.eye(N)) < 1e-10
-    
-    

--- a/bayem/correlation.py
+++ b/bayem/correlation.py
@@ -66,7 +66,6 @@ def inv_cor_exp_1d(x, l, N_blocks=1, return_sparse=True):
     C_0[-1] = ann
     C_1 = -a / (1 - a ** 2)
 
-
     CN0 = np.tile(C_0, N_blocks)
     CN1 = np.zeros(len(CN0) - 1)
     for i in range(N_blocks):
@@ -76,6 +75,7 @@ def inv_cor_exp_1d(x, l, N_blocks=1, return_sparse=True):
         return diags([CN1, CN0, CN1], [-1, 0, 1]).tocsc()
     else:
         return C_0, C_1
+
 
 def sp_logdet(M):
     """

--- a/bayem/correlation.py
+++ b/bayem/correlation.py
@@ -4,7 +4,7 @@ from scipy.sparse import diags
 from scipy.sparse.linalg import splu
 
 
-def correlation_matrix(x, l, N_blocks=1):
+def cor_exp_1d(x, l, N_blocks=1):
     """
     Builds a dense correlation matrix C with exponential kernel. For `N_blocks > 1`,
     a block matrix is returned with the only C as diagonal blocks.
@@ -26,7 +26,7 @@ def correlation_matrix(x, l, N_blocks=1):
     return block_diag(*diagonal_blocks)
 
 
-def inv_correlation_matrix(x, l, N_blocks=1, return_sparse=True):
+def inv_cor_exp_1d(x, l, N_blocks=1, return_sparse=True):
     """
     Calculates the inverse of an exponential correlation matrix analytically.
     This inverse has a tridiagonal structure and is taken from [1].

--- a/bayem/distributions.py
+++ b/bayem/distributions.py
@@ -7,7 +7,7 @@ from tabulate import tabulate
 class MVN:
     def __init__(self, mean=[0.0], precision=[[1.0]], name="MVN", parameter_names=None):
         """
-        Creates a N-dimensional multivariate normal distribution from provided 
+        Creates a N-dimensional multivariate normal distribution from provided
         `mean` μ and `precision` L with the PDF
 
            f(x) = (2π)^(-N/2) det(L)^(1/2) exp[-1/2 (x - μ)^T L (x - μ)]
@@ -22,7 +22,7 @@ class MVN:
             name of the distribution, e.g. to indicate "prior" or "posterior"
 
         parameter_names:
-            vector of N strings that name the N parameters for convenient 
+            vector of N strings that name the N parameters for convenient
             access via `self.named_mean`
         """
         self.mean = np.atleast_1d(mean).astype(float)
@@ -88,13 +88,13 @@ class MVN:
 class Gamma:
     def __init__(self, shape=1.0e-6, scale=1e6, name="Gamma"):
         """
-        Creates a Gamma distribution from provided `shape` k and `scale` θ 
+        Creates a Gamma distribution from provided `shape` k and `scale` θ
         with the PDF
 
             f(x) = 1 / [Γ(k) θ^k] x^(k-1) exp(-x/θ)
 
         where Γ denotes the Gamma function.
-        
+
         shape:
             shape parameter k
 
@@ -105,11 +105,11 @@ class Gamma:
             name of the distribution, e.g. to indicate "prior" or "posterior"
 
         Notes:
-            The default values aim at creating a non-informative gamma 
+            The default values aim at creating a non-informative gamma
             distribution. Ideally, we would have shape=0 and scale=inf, but
-            that raises numerical issues. Other authors [Kerman, Jouni. 
-            "Neutral noninformative and informative conjugate beta and gamma 
-            prior distributions." Electronic Journal of Statistics 5 (2011): 
+            that raises numerical issues. Other authors [Kerman, Jouni.
+            "Neutral noninformative and informative conjugate beta and gamma
+            prior distributions." Electronic Journal of Statistics 5 (2011):
             1450-1470.] propose Gamma(1/3, 0).
         """
         self.scale = scale

--- a/bayem/json_io.py
+++ b/bayem/json_io.py
@@ -48,7 +48,7 @@ class BayemEncoder(json.JSONEncoder):
         """
         if isinstance(obj, VBResult):
             return {"bayem.VBResult": obj.__dict__}
-        
+
         if isinstance(obj, VBOptions):
             return {"bayem.VBOptions": asdict(obj)}
 

--- a/bayem/vba.py
+++ b/bayem/vba.py
@@ -32,27 +32,27 @@ def vba(f, x0, noise0=None, jac=None, **option_kwargs):
               "noise group"
 
     x0:
-        bayem.MVN multivariate normal distribution for the model parameter 
+        bayem.MVN multivariate normal distribution for the model parameter
         prior
 
     noise0:
-        Collection* (see below) bayem.Gamma distributions for the noise (hyper) 
-        parameter prior. 
+        Collection* (see below) bayem.Gamma distributions for the noise (hyper)
+        parameter prior.
         If noise0 is None, a noninformative gamma prior is chosen
         automatically according to the number of noise groups.
 
     jac:
-        callable that takes a parameter vector as input and returns a 
+        callable that takes a parameter vector as input and returns a
         collection* (see below) of df/dmodel_paramaters matrices.
-        * jac == True indicates that the model error `f` returns a tuple 
+        * jac == True indicates that the model error `f` returns a tuple
           containing both the model error and its derivative.
         * jac == None/False falls back to a numeric implementation based on
-          central differences of `f`. 
+          central differences of `f`.
 
     option_kwargs:
-        
+
         tolerance:
-            The algorithm stops, if the change in the variational free energy 
+            The algorithm stops, if the change in the variational free energy
             to the previous iteration is below `tolerance`.
 
         maxiter:
@@ -63,22 +63,22 @@ def vba(f, x0, noise0=None, jac=None, **option_kwargs):
             for `maxtrails` iterations.
 
         update_noise:
-            Flags indicating whether or not the noise parameters should be 
+            Flags indicating whether or not the noise parameters should be
             inferred. This can be passed as a single boolean for all noise
             groups or as a dict {noise_group_key : bool}.
-        
+
         index_ARD:
-            Automatic Relevance Determination option to allow for "the automated 
-            reduction of model complexity" (Chappell et al. 2009). It should be 
-            an array containing the indexes corresponding to the position of 
+            Automatic Relevance Determination option to allow for "the automated
+            reduction of model complexity" (Chappell et al. 2009). It should be
+            an array containing the indexes corresponding to the position of
             the ARD parameters in the `x0` MVN.
 
         cdf_eps:
-            epsilon for central differences jacobian, approx 
+            epsilon for central differences jacobian, approx
             sqrt(machine precision)
 
         store_full_precision:
-            If true, includes the full precision for each iteration in the 
+            If true, includes the full precision for each iteration in the
             VBResult. Set that to False for _big_ problems to save memory.
 
 
@@ -89,19 +89,19 @@ def vba(f, x0, noise0=None, jac=None, **option_kwargs):
     =================
 
     collection*:
-        The output of `f` must match the output of `jac` and the format of 
+        The output of `f` must match the output of `jac` and the format of
         `noise0`. For clarity:
 
         type(f(theta)) | type(jac(theta)) | type(noise0)
-       ----------------+------------------+-------------- 
+       ----------------+------------------+--------------
            vector      |      matrix      |     Gamma
         list[vector]   |    list[matrix]  |  list[Gamma]
         dict{g:vector} |   dict{g:matrix} | dict{g:Gamma}
 
 
 
-    The implementation is close to the formulas of section III.C (Extending the 
-    Noise Model) with the same notation and references to each formula, with the 
+    The implementation is close to the formulas of section III.C (Extending the
+    Noise Model) with the same notation and references to each formula, with the
     only exception that capital lambda (precision) in the paper is here referred
     to as L.
 
@@ -158,7 +158,7 @@ class CDF_Jacobian:
             in `bayem.vba`
 
         cdf_eps:
-            defines the step length of parameter `x` as 
+            defines the step length of parameter `x` as
                 h = max(cdf_eps, abs(x) * cdf_eps)
         """
         self._f = f
@@ -216,22 +216,21 @@ class DictModelError:
     """
     As indicated in `bayem.vba::AdditionalNotes`, the output of the user
     defined model error `f` may have various types. This class determines
-    this type ["dict", "list", "other"] and applies the following 
-    _transformations_ to transform the output to a dict structure. 
+    this type ["dict", "list", "other"] and applies the following
+    _transformations_ to transform the output to a dict structure.
     """
 
     to_dict = {
         "dict": _identity,
         "list": _list_to_dict,
-        "other":_obj_to_dict,
+        "other": _obj_to_dict,
     }
-    
+
     from_dict = {
         "dict": _identity,
         "list": _dict_to_list,
         "other": _dict_to_obj,
     }
-
 
     def __init__(self, f, noise0, jac, options):
         self.f = f
@@ -332,9 +331,9 @@ class VBA:
             i_iter += 1
 
             self.update_parameters(k, J)
-            
+
             k, J = self.p(self.m)
-            
+
             self.update_noise(k, J)
 
             for idx in self.options.index_ARD:

--- a/bayem/vba.py
+++ b/bayem/vba.py
@@ -138,7 +138,7 @@ class VBOptions:
     update_noise: Union[Dict, bool] = True
     index_ARD: Tuple[int] = ()
 
-    cdf_eps: float = np.finfo(np.float).eps ** 0.5
+    cdf_eps: float = np.finfo(float).eps ** 0.5
 
     store_full_precision: bool = True
 

--- a/bayem/visualization.py
+++ b/bayem/visualization.py
@@ -292,8 +292,6 @@ def result_trace(result, show=True, highlight=None):
         ax_g.errorbar(x, means, yerr=sds, label=label, capsize=5, lw=1, ls=":")
     ax_g.legend()
 
-        
-
     # annotate prior and posterior
     i_posterior = result.free_energies.index(result.f_max) + 1
     ax_f.axvline(i_posterior, color=red)

--- a/tests/exp_cov_blocks.py
+++ b/tests/exp_cov_blocks.py
@@ -12,8 +12,10 @@ def correlation_func(d):
         d=d, correlation_length=l_corr, function_type="exponential"
     )
 
+
 def inv_corr(x, l, N=1):
     from scipy.sparse import diags
+
     C0, C1 = tripy.utils.inv_cov_vec_1D(x, l, np.ones_like(x))
 
     CN0 = np.tile(C0, N)
@@ -24,11 +26,12 @@ def inv_corr(x, l, N=1):
 
     return diags([CN1, CN0, CN1], [-1, 0, 1])
 
+
 # Case 1: one sensor with correlated signals in time
 C = tripy.utils.correlation_matrix(x.reshape(-1, 1), correlation_func)
 Cinv = inv_corr(x, l_corr)
 
-np.testing.assert_array_almost_equal(np.linalg.inv(C),  Cinv.todense())
+np.testing.assert_array_almost_equal(np.linalg.inv(C), Cinv.todense())
 
 
 # Case 2: two sensor, each correlated in time but not beween each other
@@ -36,5 +39,4 @@ Z = np.zeros((N, N))
 CC = np.block([[C, Z], [Z, C]])
 
 CCinv = inv_corr(x, l_corr, N=2)
-np.testing.assert_array_almost_equal(np.linalg.inv(CC),  CCinv.todense())
-
+np.testing.assert_array_almost_equal(np.linalg.inv(CC), CCinv.todense())

--- a/tests/simple_vb_with_correlation.py
+++ b/tests/simple_vb_with_correlation.py
@@ -31,13 +31,12 @@ noise_cor_matrix = bc.correlation_matrix(xs, correlation_level*L/N)
 Cinv = bc.inv_correlation_matrix(xs, correlation_level*L/N)
 
 
-def free_energy(m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv):
+def free_energy(m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv, C_inv_logdet):
     f_new = -0.5 * ((m - m0).T @ L0 @ (m - m0) + np.trace(L_inv @ L0))
     sign, logdet = np.linalg.slogdet(L)
     f_new -= 0.5 * sign * logdet
 
-    sign, logdet = np.linalg.slogdet(C_inv.todense())
-    f_new += 0.5 * sign * logdet
+    f_new += 0.5 * C_inv_logdet
     f_new += 0.5 * len(m)
 
     sign0, logdet0 = np.linalg.slogdet(L0)
@@ -63,6 +62,7 @@ def vba(f, m0, L0, s0=1e6, c0=1e-6, C_inv=None):
     if C_inv is None:
         C_inv = scipy.sparse.identity(len(k))
 
+    C_inv_logdet = bc.sp_logdet(C_inv)
 
     s = np.copy(s0)
     c = np.copy(c0)
@@ -88,7 +88,7 @@ def vba(f, m0, L0, s0=1e6, c0=1e-6, C_inv=None):
 
         print(f"current mean: {m}")
 
-        f_new = free_energy(m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv)
+        f_new = free_energy(m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv, C_inv_logdet)
 
         print(f"Free energy of iteration {i_iter} is {f_new}")
 

--- a/tests/simple_vb_with_correlation.py
+++ b/tests/simple_vb_with_correlation.py
@@ -5,17 +5,22 @@ import matplotlib.pyplot as plt
 
 import bayem.correlation as bc
 
+
 def g(theta):
     return theta[1] ** 2 + xs * theta[0]
+
 
 class F:
     def __init__(self, data):
         self.data = data
+
     def __call__(self, theta):
         k = g(theta) - self.data
         d_dm = xs
         d_dc = 2 * theta[1] * np.ones_like(xs)
         return k, np.vstack([d_dm, d_dc]).T
+
+
 param = [5, 7]
 param_prec = 0.001
 
@@ -26,9 +31,9 @@ perfect_data = g(param)
 noise_std = 0.2
 
 correlation_level = 5
-noise_cor_matrix = bc.correlation_matrix(xs, correlation_level*L/N)
+noise_cor_matrix = bc.cor_exp_1d(xs, correlation_level * L / N)
 
-Cinv = bc.inv_correlation_matrix(xs, correlation_level*L/N)
+Cinv = bc.inv_cor_exp_1d(xs, correlation_level * L / N)
 
 
 def free_energy(m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv, C_inv_logdet):
@@ -53,12 +58,13 @@ def free_energy(m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv, C_inv_logdet):
     f_new += -N / 2 * np.log(2 * np.pi) - special.gammaln(c0) - c0 * np.log(s0)
     return f_new
 
+
 def vba(f, m0, L0, s0=1e6, c0=1e-6, C_inv=None):
     m = np.copy(m0)
     L = np.array(L0)
 
     k, J = f(m)
-   
+
     if C_inv is None:
         C_inv = scipy.sparse.identity(len(k))
 
@@ -78,9 +84,9 @@ def vba(f, m0, L0, s0=1e6, c0=1e-6, C_inv=None):
         L_inv = np.linalg.inv(L)
         Lm = s * c * J.T @ C_inv @ (-k + J @ m) + L0 @ m0
         m = Lm @ L_inv
-        
+
         k, J = f(m)
-        
+
         # update noise
         c = len(k) / 2 + c0
         s_inv = 1 / s0 + 0.5 * k.T @ C_inv @ k + 0.5 * np.trace(L_inv @ J.T @ C_inv @ J)
@@ -88,7 +94,9 @@ def vba(f, m0, L0, s0=1e6, c0=1e-6, C_inv=None):
 
         print(f"current mean: {m}")
 
-        f_new = free_energy(m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv, C_inv_logdet)
+        f_new = free_energy(
+            m, m0, L, L0, L_inv, s, s0, c, c0, k, J, C_inv, C_inv_logdet
+        )
 
         print(f"Free energy of iteration {i_iter} is {f_new}")
 
@@ -105,105 +113,118 @@ def vba(f, m0, L0, s0=1e6, c0=1e-6, C_inv=None):
 
     return {"mean": m, "precision": L, "scale": s, "shape": c, "F": f_new}
 
+
 def do_vb(_plot=True, C_inv=None):
     np.random.seed(6174)
     correlated_noise = np.random.multivariate_normal(
         np.zeros(len(xs)),
         noise_cor_matrix * noise_std ** 2,
     )
-    
+
     correlated_data = perfect_data + correlated_noise
     f = F(correlated_data)
-    
+
     if _plot:
         plt.figure()
-        plt.plot(perfect_data, label='perfect', marker='*', linestyle='')
-        plt.plot(correlated_data, label='noisy', marker='+', linestyle='')
-        plt.title('Data')
-        plt.legend(); plt.show()
-    
+        plt.plot(perfect_data, label="perfect", marker="*", linestyle="")
+        plt.plot(correlated_data, label="noisy", marker="+", linestyle="")
+        plt.title("Data")
+        plt.legend()
+        plt.show()
+
     m0 = np.array([2, 19])
     L0 = np.array([[param_prec, 0], [0, param_prec]])
 
     info = vba(f, m0, L0, C_inv=C_inv)
     for what, value in info.items():
         print(what, value)
-    noise_prec_mean = info['shape'] * info['scale']
+    noise_prec_mean = info["shape"] * info["scale"]
     print(f"Noise-Std from mean of identified precision: {noise_prec_mean ** (-0.5)} .")
-    
+
     return info
+
 
 def plot_posteriors(infos, labels):
     from scipy.stats import norm
+
     stds1 = []
     stds2 = []
     means1 = []
     means2 = []
     for info in infos:
-        stds1.append(info['precision'][0,0]**(-0.5))
-        stds2.append(info['precision'][1,1]**(-0.5))
-        means1.append(info['mean'][0])
-        means2.append(info['mean'][1])
+        stds1.append(info["precision"][0, 0] ** (-0.5))
+        stds2.append(info["precision"][1, 1] ** (-0.5))
+        means1.append(info["mean"][0])
+        means2.append(info["mean"][1])
     stds1_max = max(stds1)
     stds2_max = max(stds2)
     _min1 = min(param[0], min(means1))
     _max1 = max(param[0], max(means1))
     _min2 = min(param[1], min(means2))
     _max2 = max(param[1], max(means2))
-    xs1 = np.linspace(_min1-3*stds1_max, _max1+3*stds1_max, 1000)
-    xs2 = np.linspace(_min2-3*stds2_max, _max2+3*stds2_max, 1000)
+    xs1 = np.linspace(_min1 - 3 * stds1_max, _max1 + 3 * stds1_max, 1000)
+    xs2 = np.linspace(_min2 - 3 * stds2_max, _max2 + 3 * stds2_max, 1000)
     plt.figure()
     for i, info in enumerate(infos):
         dis1 = norm(means1[i], stds1[i])
         pdfs1 = dis1.pdf(xs1)
         plt.plot(xs1, pdfs1, label=labels[i])
-    plt.axvline(x=param[0], ls='-', color='blue')
+    plt.axvline(x=param[0], ls="-", color="blue")
     plt.legend()
-    plt.title('Posterior of parameter 1')
-    
+    plt.title("Posterior of parameter 1")
+
     plt.figure()
     for i, info in enumerate(infos):
         dis2 = norm(means2[i], stds2[i])
         pdfs2 = dis2.pdf(xs2)
         plt.plot(xs2, pdfs2, label=labels[i])
-    plt.axvline(x=param[1], ls='-', color='blue')
+    plt.axvline(x=param[1], ls="-", color="blue")
     plt.legend()
-    plt.title('Posterior of parameter 2')
-    
+    plt.title("Posterior of parameter 2")
+
     plt.show()
-    
+
 
 if __name__ == "__main__":
     infos = []
     labels = []
-    
+
     info = do_vb()
-    infos.append(info); labels.append('Without Cor. matrix')
-    
+    infos.append(info)
+    labels.append("Without Cor. matrix")
+
     info2 = do_vb(C_inv=Cinv)
-    infos.append(info2); labels.append('With target Cor. matrix')
-    
-    _factor = 1/2
-    info3 = do_vb(C_inv=Cinv/_factor)
-    infos.append(info3); labels.append(f"With {_factor} * target Cor. matrix")
-    
+    infos.append(info2)
+    labels.append("With target Cor. matrix")
+
+    _factor = 1 / 2
+    info3 = do_vb(C_inv=Cinv / _factor)
+    infos.append(info3)
+    labels.append(f"With {_factor} * target Cor. matrix")
+
     # In the first scenario we obtain more certain (higher precision) inference of parameters
     # , since we did not account for correlation of data.
-    assert info['precision'][0,0] > info2['precision'][0,0]
-    assert info['precision'][1,1] > info2['precision'][1,1]
-    
+    assert info["precision"][0, 0] > info2["precision"][0, 0]
+    assert info["precision"][1, 1] > info2["precision"][1, 1]
+
     ## Since correlation matrix in info3 is half of info2 (only a scaling):
-        # 1) The inferred parameters in info2 and info3 must be the same.
-        # 2) The inferred noise precision in info3 must be half of info2.
-            # This ratio, however, only goes to the mean of the identified noise, meaning that:
-                # The scales are different by the factor 2.
-                # But the shapes are the same (we only have shift of one distribution from the other). 
-        # 3) The converged free energy in info2 and info3 is the same.
-    assert np.linalg.norm(info3['mean'] - info2['mean']) / np.linalg.norm(info2['mean']) < 1e-6
-    assert np.linalg.norm(info3['precision'] - info2['precision']) / np.linalg.norm(info2['precision']) < 1e-6
-    assert abs((info3['shape'] - info2['shape']) / info2['shape']) < 1e-6
-    assert abs((info3['scale'] - _factor * info2['scale']) / info2['scale']) < 1e-6
-    assert abs((info3['F'] - info2['F']) / info2['F']) < 1e-5
-    
-    
+    # 1) The inferred parameters in info2 and info3 must be the same.
+    # 2) The inferred noise precision in info3 must be half of info2.
+    # This ratio, however, only goes to the mean of the identified noise, meaning that:
+    # The scales are different by the factor 2.
+    # But the shapes are the same (we only have shift of one distribution from the other).
+    # 3) The converged free energy in info2 and info3 is the same.
+    assert (
+        np.linalg.norm(info3["mean"] - info2["mean"]) / np.linalg.norm(info2["mean"])
+        < 1e-6
+    )
+    assert (
+        np.linalg.norm(info3["precision"] - info2["precision"])
+        / np.linalg.norm(info2["precision"])
+        < 1e-6
+    )
+    assert abs((info3["shape"] - info2["shape"]) / info2["shape"]) < 1e-6
+    assert abs((info3["scale"] - _factor * info2["scale"]) / info2["scale"]) < 1e-6
+    assert abs((info3["F"] - info2["F"]) / info2["F"]) < 1e-5
+
     plot_posteriors(infos, labels)

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -6,11 +6,11 @@ N = 100
 l = 2
 xs = np.linspace(1, l, N)
 correlation_length = 0.5
-C = bayem.correlation_matrix(xs, correlation_length)
+C = bayem.cor_exp_1d(xs, correlation_length)
 
 
 def test_single_sensor():
-    C_inv = bayem.inv_correlation_matrix(xs, correlation_length)
+    C_inv = bayem.inv_cor_exp_1d(xs, correlation_length)
     np.testing.assert_array_almost_equal(C_inv @ C, np.eye(N))
 
 
@@ -20,17 +20,17 @@ def test_two_sensors():
     CC = np.block([[C, Z], [Z, C]])
 
     np.testing.assert_array_almost_equal(
-        CC, bayem.correlation_matrix(xs, correlation_length, N_blocks=2)
+        CC, bayem.cor_exp_1d(xs, correlation_length, N_blocks=2)
     )
 
-    CCinv = bayem.inv_correlation_matrix(xs, correlation_length, N_blocks=2)
+    CCinv = bayem.inv_cor_exp_1d(xs, correlation_length, N_blocks=2)
     np.testing.assert_array_almost_equal(CC @ CCinv, np.eye(2 * N))
 
 
 def test_logdet():
     from scipy.sparse.linalg import splu
 
-    C_inv = bayem.inv_correlation_matrix(xs, l)
+    C_inv = bayem.inv_cor_exp_1d(xs, l)
     logdet_numpy = np.linalg.slogdet(C_inv.todense())[1]
     logdet_lu = bayem.sp_logdet(C_inv)
 

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,32 +1,32 @@
-"""
-Created on Mon Dec 13 2021
-
-@author: ajafari
-"""
-import unittest
 import numpy as np
 import bayem
 
-class TestCorrelation(unittest.TestCase):
-    def setUp(self):
-        pass
-    
-    def test_inverting_exponential_correlation_1D(self):
-        N = 100
-        L = 2
-        xs = np.linspace(1, L, N).reshape((N,1))
-        correlation_level = 3
-        correlation_length = correlation_level*L/N
-        kernel = bayem.CorrelationFunction(correlation_length=correlation_length)
-        # Case 1: one sensor with correlated signals in time
-        C = bayem.correlation_matrix(xs, correlation_func=kernel)
-        C_inv = bayem.inv_cov_vec_1D(xs.flatten(), correlation_length)
-        np.testing.assert_array_almost_equal(C_inv@C, np.eye(N))
-        # Case 2: two sensor, each correlated in time but not beween each other
-        Z = np.zeros((N, N))
-        CC = np.block([[C, Z], [Z, C]])
-        CCinv = bayem.inv_cov_vec_1D(xs.flatten(), correlation_length, N_blocks=2)
-        np.testing.assert_array_almost_equal(CC@CCinv, np.eye(2*N))
-        
+
+N = 100
+L = 2
+xs = np.linspace(1, L, N)
+correlation_length = 0.5
+C = bayem.correlation_matrix(xs, correlation_length)
+
+
+def test_single_sensor():
+    C_inv = bayem.inv_correlation_matrix(xs, correlation_length)
+    np.testing.assert_array_almost_equal(C_inv @ C, np.eye(N))
+
+
+def test_two_sensors():
+
+    Z = np.zeros((N, N))
+    CC = np.block([[C, Z], [Z, C]])
+
+    np.testing.assert_array_almost_equal(
+        CC, bayem.correlation_matrix(xs, correlation_length, N_blocks=2)
+    )
+
+    CCinv = bayem.inv_correlation_matrix(xs, correlation_length, N_blocks=2)
+    np.testing.assert_array_almost_equal(CC @ CCinv, np.eye(2 * N))
+
+
 if __name__ == "__main__":
-    unittest.main()
+    test_single_sensor()
+    test_two_sensors()

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,10 +1,11 @@
 import numpy as np
 import bayem
-
+import zaya
+import pytest
 
 N = 100
-L = 2
-xs = np.linspace(1, L, N)
+l = 2
+xs = np.linspace(1, l, N)
 correlation_length = 0.5
 C = bayem.correlation_matrix(xs, correlation_length)
 
@@ -27,6 +28,17 @@ def test_two_sensors():
     np.testing.assert_array_almost_equal(CC @ CCinv, np.eye(2 * N))
 
 
+def test_logdet():
+    from scipy.sparse.linalg import splu
+
+    C_inv = bayem.inv_correlation_matrix(xs, l)
+    logdet_numpy = np.linalg.slogdet(C_inv.todense())[1]
+    logdet_lu = bayem.sp_logdet(C_inv)
+
+    assert logdet_numpy == pytest.approx(logdet_lu)
+
+
 if __name__ == "__main__":
     test_single_sensor()
     test_two_sensors()
+    test_logdet()

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -1,6 +1,5 @@
 import numpy as np
 import bayem
-import zaya
 import pytest
 
 N = 100

--- a/tests/test_vb_ARD.py
+++ b/tests/test_vb_ARD.py
@@ -73,6 +73,7 @@ info = bayem.vba(
     update_noise=True,
 )
 
+
 @pytest.mark.skip(reason="There is something going wrong in this test design.")
 def test_checks():
     means, sds = info.param.mean, info.param.std_diag

--- a/tests/test_vb_minimal.py
+++ b/tests/test_vb_minimal.py
@@ -29,7 +29,9 @@ def test_results():
     post_noise_std = 1.0 / post_noise_precision ** 0.5
     assert post_noise_std == pytest.approx(sd, rel=0.01)
 
-    assert info.nit < 4 # For such linear regression we do expect to have very few iterations.
+    assert (
+        info.nit < 4
+    )  # For such linear regression we do expect to have very few iterations.
     assert info.t < 0.1
 
     info.summary(True)

--- a/tests/test_vb_noises.py
+++ b/tests/test_vb_noises.py
@@ -98,9 +98,9 @@ class TestTwoNoises(unittest.TestCase):
         wrong_noise = bayem.Gamma((1, 1), (2, 2))
         with self.assertRaises(Exception):
             bayem.vba(me, bayem.MVN(7, 12), wrong_noise)
-    
+
     def test_several_noises_mixed(self):
-        """ Test if an identifiable noise group is updated and another that is prescribed is not."""
+        """Test if an identifiable noise group is updated and another that is prescribed is not."""
         noise_prior = {}
         update_noise = {}
         noise_prior["group0"] = bayem.Gamma.FromSDQuantiles(
@@ -112,12 +112,12 @@ class TestTwoNoises(unittest.TestCase):
         )
         update_noise["group1"] = True
         info = self.run_test(noise_prior, delta=0.05, update_noise=update_noise)
-        
-        assert (info.noise['group0'].scale == noise_prior['group0'].scale)
-        assert (info.noise['group0'].shape == noise_prior['group0'].shape)
-        
-        assert (info.noise['group1'].scale != noise_prior['group1'].scale)
-        assert (info.noise['group1'].shape != noise_prior['group1'].shape)
+
+        assert info.noise["group0"].scale == noise_prior["group0"].scale
+        assert info.noise["group0"].shape == noise_prior["group0"].shape
+
+        assert info.noise["group1"].scale != noise_prior["group1"].scale
+        assert info.noise["group1"].shape != noise_prior["group1"].shape
 
 
 if __name__ == "__main__":

--- a/tests/test_vb_visu.py
+++ b/tests/test_vb_visu.py
@@ -8,9 +8,10 @@ import numpy as np
 import pytest
 from imageio import imread
 
+
 def compare_plt(reference_filename, generate_ref_img):
     ref_img_name = Path(__file__).absolute().parent / reference_filename
-    if generate_ref_img: 
+    if generate_ref_img:
         plt.savefig(ref_img_name, dpi=300)
         return
 
@@ -23,12 +24,15 @@ def compare_plt(reference_filename, generate_ref_img):
 
         assert np.linalg.norm(test_img - ref_img) == pytest.approx(0)
 
+
 np.random.seed(6174)
 t = np.linspace(1, 2, 10)
 noise = np.random.normal(0, 0.42, len(t))
 
+
 def f(x):
-    return t * x[0]**2 - t * 9 + noise
+    return t * x[0] ** 2 - t * 9 + noise
+
 
 info = bayem.vba(f, x0=bayem.MVN([2], [0.5]), noise0=bayem.Gamma(1, 2))
 
@@ -36,6 +40,7 @@ info = bayem.vba(f, x0=bayem.MVN([2], [0.5]), noise0=bayem.Gamma(1, 2))
 def test_pair_plot(generate_ref_img=False):
     visu.pair_plot(info, show=False)
     compare_plt("ref_pair_plot.png", generate_ref_img=generate_ref_img)
+
 
 def test_trace_plot(generate_ref_img=False):
     visu.result_trace(info, show=False)


### PR DESCRIPTION
The only practical kernel (for now?) is the exponential kernel as we have the analytic inverse. So I removed the rest. Also, I adapted the simple_vb_with_c to use the inverse correlation matrix. The only annoying place where the sparse C_inv is turned to dense is the 
~~~
sign, logdet = np.linalg.slogdet(C_inv)
~~~
as this method is not implemented for sparse matrices. A possible remedy is to use the identity
~~~
log(det(M)) = trace(log(M))
~~~
which would translate to 
~~~
C_inv_log = scipy.linalg.logm(C_inv)
logdet = C_inv_log.trace()
~~~
But that fails with a error that C_inv is not square which IMO makes no sense...